### PR TITLE
Add missing methods to ImmutableMapFactory

### DIFF
--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/factory/map/ImmutableMapFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.collections.api.factory.map;
 import java.util.Map;
 
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MapIterable;
 
 public interface ImmutableMapFactory
 {
@@ -59,12 +60,37 @@ public interface ImmutableMapFactory
 
     <K, V> ImmutableMap<K, V> with(K key1, V value1, K key2, V value2, K key3, V value3, K key4, V value4);
 
+    /**
+     * @deprecated use {@link #withMap(Map)} instead (inlineable).
+     */
+    @Deprecated
     <K, V> ImmutableMap<K, V> ofMap(Map<K, V> map);
 
     /**
      * Same as {@link #withAll(Map)}.
+     * @deprecated since 10.3.0, use {@link #withMap(Map)} instead.
      */
+    @Deprecated
     <K, V> ImmutableMap<K, V> ofAll(Map<K, V> map);
 
+    /**
+     * @deprecated since 10.3.0, use {@link #withMap(Map)} instead.
+     */
+    @Deprecated
     <K, V> ImmutableMap<K, V> withAll(Map<K, V> map);
+
+    /**
+     * @since 10.3.0
+     */
+    <K, V> ImmutableMap<K, V> withMap(Map<K, V> map);
+
+    /**
+     * @since 10.3.0
+     */
+    <K, V> ImmutableMap<K, V> ofMapIterable(MapIterable<K, V> mapIterable);
+
+    /**
+     * @since 10.3.0
+     */
+    <K, V> ImmutableMap<K, V> withMapIterable(MapIterable<K, V> mapIterable);
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/ImmutableBiMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/bimap/immutable/ImmutableBiMapFactoryImpl.java
@@ -116,8 +116,8 @@ public class ImmutableBiMapFactoryImpl implements ImmutableBiMapFactory
         {
             return this.withAll((MutableBiMap<K, V>) map);
         }
-        ImmutableMap<K, V> immutableMap = Maps.immutable.withAll(map);
-        return new ImmutableHashBiMap<>(immutableMap, Maps.immutable.withAll(MapIterate.flipUniqueValues(immutableMap)));
+        ImmutableMap<K, V> immutableMap = Maps.immutable.withMap(map);
+        return new ImmutableHashBiMap<>(immutableMap, Maps.immutable.withMap(MapIterate.flipUniqueValues(immutableMap)));
     }
 
     @Override
@@ -129,7 +129,7 @@ public class ImmutableBiMapFactoryImpl implements ImmutableBiMapFactory
     @Override
     public <K, V> ImmutableBiMap<K, V> withAll(MutableBiMap<K, V> biMap)
     {
-        return new ImmutableHashBiMap<>(Maps.immutable.withAll(biMap), Maps.immutable.withAll(biMap.inverse()));
+        return new ImmutableHashBiMap<>(Maps.immutable.withMap(biMap), Maps.immutable.withMap(biMap.inverse()));
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/immutable/ImmutableMapFactoryImpl.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 
 import org.eclipse.collections.api.factory.map.ImmutableMapFactory;
 import org.eclipse.collections.api.map.ImmutableMap;
+import org.eclipse.collections.api.map.MapIterable;
 
 public class ImmutableMapFactoryImpl implements ImmutableMapFactory
 {
@@ -132,23 +133,42 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
     }
 
     /**
-     * @deprecated use {@link #ofAll(Map)} instead (inlineable)
+     * @deprecated use {@link #withMap(Map)} instead (inlineable).
      */
     @Override
     @Deprecated
     public <K, V> ImmutableMap<K, V> ofMap(Map<K, V> map)
     {
-        return this.ofAll(map);
+        return this.withMap(map);
     }
 
+    /**
+     * Same as {@link #withMap(Map)}.
+     * @deprecated since 10.3.0, use {@link #withMap(Map)} instead.
+     */
     @Override
+    @Deprecated
     public <K, V> ImmutableMap<K, V> ofAll(Map<K, V> map)
     {
-        return this.withAll(map);
+        return this.withMap(map);
     }
 
+    /**
+     * Same as {@link #withMap(Map)}.
+     * @deprecated since 10.3.0, use {@link #withMap(Map)} instead.
+     */
     @Override
+    @Deprecated
     public <K, V> ImmutableMap<K, V> withAll(Map<K, V> map)
+    {
+        return this.withMap(map);
+    }
+
+    /**
+     * @since 10.3.0
+     */
+    @Override
+    public <K, V> ImmutableMap<K, V> withMap(Map<K, V> map)
     {
         if (map.isEmpty())
         {
@@ -183,5 +203,23 @@ public class ImmutableMapFactoryImpl implements ImmutableMapFactory
             default:
                 throw new AssertionError();
         }
+    }
+
+    /**
+     * @since 10.3.0
+     */
+    @Override
+    public <K, V> ImmutableMap<K, V> ofMapIterable(MapIterable<K, V> mapIterable)
+    {
+        return this.withMapIterable(mapIterable);
+    }
+
+    /**
+     * @since 10.3.0
+     */
+    @Override
+    public <K, V> ImmutableMap<K, V> withMapIterable(MapIterable<K, V> mapIterable)
+    {
+        return (ImmutableMap<K, V>) mapIterable.toImmutable();
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/AbstractMutableMap.java
@@ -92,7 +92,7 @@ public abstract class AbstractMutableMap<K, V> extends AbstractMutableMapIterabl
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.withAll(this);
+        return Maps.immutable.withMap(this);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -2306,6 +2306,6 @@ public final class ConcurrentHashMap<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.ofMap(this);
+        return Maps.immutable.withMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -2445,6 +2445,6 @@ public class ConcurrentHashMapUnsafe<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.ofMap(this);
+        return Maps.immutable.withMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentMutableHashMap.java
@@ -447,6 +447,6 @@ public final class ConcurrentMutableHashMap<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.ofMap(this);
+        return Maps.immutable.withMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MapAdapter.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/MapAdapter.java
@@ -190,6 +190,6 @@ public class MapAdapter<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.ofMap(this);
+        return Maps.immutable.withMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/SynchronizedMutableMap.java
@@ -478,7 +478,7 @@ public class SynchronizedMutableMap<K, V>
     {
         synchronized (this.lock)
         {
-            return Maps.immutable.withAll(this);
+            return Maps.immutable.withMap(this);
         }
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -3300,6 +3300,6 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.withAll(this);
+        return Maps.immutable.withMap(this);
     }
 }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMap.java
@@ -411,7 +411,7 @@ public class UnmodifiableMutableMap<K, V>
     @Override
     public ImmutableMap<K, V> toImmutable()
     {
-        return Maps.immutable.withAll(this);
+        return Maps.immutable.withMap(this);
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/BiMapsTest.java
@@ -41,8 +41,8 @@ public class BiMapsTest
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.of(1, "2", 3, "4", 5, "6", 7, "8"));
         Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8"))));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, 8))));
-        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(Maps.immutable.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
-        Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(Maps.immutable.ofAll(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
+        Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(Maps.immutable.withMap(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
+        Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(Maps.immutable.withMap(UnifiedMap.newMapWith(Tuples.pair(1, "2"), Tuples.pair(3, "4"), Tuples.pair(5, "6"), Tuples.pair(7, "8")))));
         Assert.assertEquals(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8"), factory.ofAll(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8")));
         Verify.assertInstanceOf(ImmutableBiMap.class, factory.ofAll(HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8")));
         Map<Integer, String> map1 = HashBiMap.newWithKeysValues(1, "2", 3, "4", 5, "6", 7, "8");

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -84,17 +84,17 @@ public class MapsTest
     @Test
     public void copyMap()
     {
-        Assert.assertEquals(Maps.fixedSize.of(1, "One"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
-        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One")));
+        Assert.assertEquals(Maps.fixedSize.of(1, "One"), Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One")));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One")));
 
-        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
-        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos"), Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos")));
 
-        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
-        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Assert.assertEquals(Maps.fixedSize.of(1, "One", 2, "Dos", 3, "Drei"), Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei")));
 
-        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
-        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMap(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
 
         Assert.assertEquals(Maps.immutable.empty(), Maps.immutable.withMapIterable(Maps.immutable.with()));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(Maps.immutable.with()));

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/factory/MapsTest.java
@@ -95,6 +95,39 @@ public class MapsTest
 
         Assert.assertEquals(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro"), Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
         Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.ofAll(UnifiedMap.newWithKeysValues(1, "One", 2, "Dos", 3, "Drei", 4, "Quatro")));
+
+        Assert.assertEquals(Maps.immutable.empty(), Maps.immutable.withMapIterable(Maps.immutable.with()));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(Maps.immutable.with()));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(1), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(1)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(1)));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(2), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(2)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(2)));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(3), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(3)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(3)));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(4), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(4)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(4)));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(5), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(5)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(5)));
+
+        Assert.assertEquals(MapsTest.createMapOfSize(10), Maps.immutable.withMapIterable(MapsTest.createMapOfSize(10)));
+        Verify.assertInstanceOf(ImmutableMap.class, Maps.immutable.withMapIterable(MapsTest.createMapOfSize(10)));
+    }
+
+    private static ImmutableMap<Integer, Integer> createMapOfSize(int size)
+    {
+        UnifiedMap<Integer, Integer> map = UnifiedMap.newMap(size);
+
+        for (int i = 0; i < size; i++)
+        {
+            map.put(i, i);
+        }
+
+        return Maps.immutable.withMap(map);
     }
 
     @Test


### PR DESCRIPTION
Additional changes include -
1. Replace usage of newly deprecated methods.
2. Update interface Javadoc to align with deprecated
implementation in (ImmutableMapFactoryImpl#ofMap).

Closes gh-738

Signed-off-by: Kedar Joshi <kdar_joshi@yahoo.com>