### PR TITLE
Clean up BND instructions

### DIFF
--- a/eclipse-collections-api/bnd.bnd
+++ b/eclipse-collections-api/bnd.bnd
@@ -1,6 +1,9 @@
-package-version=${version;===;${Bundle-Version}}
+package-version=${versionmask;===;${Bundle-Version}}
 
 Automatic-Module-Name: org.eclipse.collections.api
 Bundle-SymbolicName: org.eclipse.collections.api
+# explicitly set bundle-developers to avoid bnd-maven-plugin raising warnings for missing ids in the developers section of pom.xml
+Bundle-Developers: Eclipse Collections
+
 Export-Package: \
   *;version="${package-version}"

--- a/eclipse-collections/bnd.bnd
+++ b/eclipse-collections/bnd.bnd
@@ -1,7 +1,15 @@
-package-version=${version;===;${Bundle-Version}}
+package-version=${versionmask;===;${Bundle-Version}}
 
 Automatic-Module-Name: org.eclipse.collections.impl
 Bundle-SymbolicName: org.eclipse.collections.impl
+
+# explicitly set bundle-developers to avoid bnd-maven-plugin raising warnings for missing ids in the developers section of pom.xml
+Bundle-Developers: Eclipse Collections
+
+# explicitly set bundle-description to avoid the XML indentation whitespace from the pom.xml <description> tag appearing here
+Bundle-Description: Eclipse Collections is a collections framework for Java. It has JDK-compatible List, Set and Map\
+ implementations with a rich API and set of utility classes that work with any JDK compatible Collections,\
+ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk collection framework.
 
 Export-Package: \
 	org.eclipse.collections.impl.*;version="${package-version}"

--- a/p2-repository/org.eclipse.collections/osgi.bnd
+++ b/p2-repository/org.eclipse.collections/osgi.bnd
@@ -1,6 +1,4 @@
-package-version=${version;===;${Bundle-Version}}
-eclipse-collections-api-version=${version;===;8.1.0}
-jcip-annotations-version=${version;===;1.0}
+package-version=${versionmask;===;${Bundle-Version}}
 
 Export-Package: \
  !about.html,!about_files, \


### PR DESCRIPTION
* Remove jcni version (it's been removed in 2017 from the code base).
* Remove api version (it's never been used since moving the code to eclipse).
* Set a fixed Bundle-Developer in generated manifests to avoid bnd-maven-plugin complaining about all the developers in the parent pom.xml not having a mandatory ID.
* Set the Bundle-Description header in BND. Otherwise the pom.xml description is taken for that header, and unfortunately the pom.xml description tag contains whitespace from the XML formatting and indenting.
* Use the versionmask macro instead of the version macro. version is an alias for versionmask that is for compatibility only and should not be used.

If you are wondering what the above means:
![grafik](https://github.com/eclipse/eclipse-collections/assets/406876/0de9a526-b6d5-4966-9117-736488be35aa)
![grafik](https://github.com/eclipse/eclipse-collections/assets/406876/64aa68c2-84e3-492b-9267-da3c1bd12b19)
