### PR TITLE
#1640 Issue: added condition for empty list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
@@ -605,6 +605,9 @@ final class ImmutableArrayList<T>
     {
         int endIndex = this.detectNotIndex(predicate);
         T[] result = (T[]) new Object[endIndex];
+
+        if(endIndex <= 0)return new ImmutableEmptyList<>();
+        
         System.arraycopy(this.items, 0, result, 0, endIndex);
         return new ImmutableArrayList<>(result);
     }
@@ -624,6 +627,9 @@ final class ImmutableArrayList<T>
     {
         int startIndex = this.detectNotIndex(predicate);
         int resultSize = this.size() - startIndex;
+
+        if(resultSize <= 0)return new ImmutableEmptyList<>();
+
         T[] result = (T[]) new Object[resultSize];
         System.arraycopy(this.items, startIndex, result, 0, resultSize);
         return new ImmutableArrayList<>(result);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
@@ -603,13 +603,11 @@ final class ImmutableArrayList<T>
     @Override
     public ImmutableList<T> takeWhile(Predicate<? super T> predicate)
     {
-        int endIndex = this.detectNotIndex(predicate);
-        T[] result = (T[]) new Object[endIndex];
-
-        if(endIndex <= 0)return new ImmutableEmptyList<>();
-        
-        System.arraycopy(this.items, 0, result, 0, endIndex);
-        return new ImmutableArrayList<>(result);
+        int startIndex = this.detectNotIndex(predicate);
+        int resultSize = this.size() - startIndex;
+        T[] result = (T[]) new Object[resultSize];
+        System.arraycopy(this.items, startIndex, result, 0, resultSize);
+        return Lists.immutable.with(result);
     }
 
     @Override

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/ImmutableArrayList.java
@@ -625,12 +625,9 @@ final class ImmutableArrayList<T>
     {
         int startIndex = this.detectNotIndex(predicate);
         int resultSize = this.size() - startIndex;
-
-        if(resultSize <= 0)return new ImmutableEmptyList<>();
-
         T[] result = (T[]) new Object[resultSize];
         System.arraycopy(this.items, startIndex, result, 0, resultSize);
-        return new ImmutableArrayList<>(result);
+        return Lists.immutable.with(result);
     }
 
     @Override


### PR DESCRIPTION
This PR addresses the issue where takeWhile() and dropWhile() methods always return ImmutableArrayList. 

Now, these methods return ImmutableEmptyList when applicable, improving the performance and correctness of the code.