### PR TITLE
Optimize immutable primitive ArrayList creation from primitive iterables.

### DIFF
--- a/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/api/primitiveIterable.stg
@@ -70,7 +70,26 @@ public interface <name>Iterable extends PrimitiveIterable
     /**
      * Converts the <name>Iterable to a primitive <type> array.
      */
-    <type>[] toArray();
+    default <type>[] toArray()
+    {
+        return this.toSizedArray(this.size());
+    }
+
+    /**
+     * Converts the <name>Iterable to a primitive <type> array up to the specified size.
+     *
+     * @since 12.0
+     */
+    default <type>[] toSizedArray(int size)
+    {
+        <type>[] array = new <type>[size];
+        int i = 0;
+        for (<name>Iterator it = this.<type>Iterator(); it.hasNext() && size > i; )
+        {
+            array[i++] = it.next();
+        }
+        return array;
+    }
 
     /**
      * Converts the <name>Iterable to a primitive <type> array. If the collection fits into the provided array it is used

--- a/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/bag/mutable/primitiveHashBag.stg
@@ -723,12 +723,18 @@ public class <name>HashBag
     @Override
     public <type>[] toArray()
     {
-        <type>[] array = new <type>[this.size()];
+        return this.toSizedArray(this.size());
+    }
+
+    @Override
+    public <type>[] toSizedArray(final int size)
+    {
+        <type>[] array = new <type>[size];
         int[] index = {0};
 
         this.forEachWithOccurrences((<type> each, int occurrences) ->
         {
-            for (int i = 0; i \< occurrences; i++)
+            for (int i = 0; index[0] \< size && i \< occurrences; i++)
             {
                 array[index[0]] = each;
                 index[0]++;

--- a/eclipse-collections-code-generator/src/main/resources/impl/lazy/abstractLazyPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/lazy/abstractLazyPrimitiveIterable.stg
@@ -236,12 +236,6 @@ public abstract class AbstractLazy<name>Iterable implements Lazy<name>Iterable
     }
 
     @Override
-    public <type>[] toArray()
-    {
-        return this.toList().toArray();
-    }
-
-    @Override
     public Mutable<name>List toList()
     {
         final Mutable<name>List list = <name>Lists.mutable.empty();

--- a/eclipse-collections-code-generator/src/main/resources/impl/lazy/tapPrimitiveIterable.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/lazy/tapPrimitiveIterable.stg
@@ -37,6 +37,12 @@ public class Tap<name>Iterable
     }
 
     @Override
+    public <type>[] toArray()
+    {
+        return this.toSizedArray(this.adapted.size());
+    }
+
+    @Override
     public void each(<name>Procedure procedure)
     {
         this.adapted.forEach(each ->

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveArrayList.stg
@@ -86,6 +86,11 @@ final class Immutable<name>ArrayList
         return new Immutable<name>ArrayList(iterable.toArray());
     }
 
+    public static Immutable<name>ArrayList newList(<name>Iterable iterable, int size)
+    {
+        return new Immutable<name>ArrayList(iterable.toSizedArray(size));
+    }
+
     public static Immutable<name>ArrayList newListWith(<type>... elements)
     {
         <type>[] newArray = new <type>[elements.length];

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveListFactoryImpl.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/immutable/immutablePrimitiveListFactoryImpl.stg
@@ -93,15 +93,20 @@ public class Immutable<name>ListFactoryImpl implements Immutable<name>ListFactor
         {
             return (Immutable<name>List) items;
         }
-        if (items == null || items.size() == 0)
+        if (items == null)
         {
             return this.with();
         }
-        if (items.size() == 1)
+        int size = items.size();
+        if (size == 0)
         {
-            return this.with(items.toArray()[0]);
+            return this.with();
         }
-        return Immutable<name>ArrayList.newList(items);
+        if (size == 1)
+        {
+            return this.with(items.<type>Iterator().next());
+        }
+        return Immutable<name>ArrayList.newList(items, size);
     }
 
     /**

--- a/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
+++ b/eclipse-collections-code-generator/src/main/resources/impl/list/mutable/primitiveArrayList.stg
@@ -856,8 +856,15 @@ public class <name>ArrayList extends Abstract<name>Iterable
     @Override
     public <type>[] toArray()
     {
-        <type>[] newItems = new <type>[this.size];
-        System.arraycopy(this.items, 0, newItems, 0, this.size);
+        return this.toSizedArray(this.size);
+    }
+
+    @Override
+    public <type>[] toSizedArray(int s)
+    {
+        <type>[] newItems = new <type>[s];
+        int newSize = Math.min(s, this.size);
+        System.arraycopy(this.items, 0, newItems, 0, newSize);
         return newItems;
     }
 

--- a/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
+++ b/eclipse-collections-code-generator/src/main/resources/test/collection/mutable/abstractPrimitiveIterableTestCase.stg
@@ -917,6 +917,27 @@ public void sumConsistentRounding()
     }
 
     @Test
+    public void toSizedArray()
+    {
+        <name>Iterable iterable = this.newWith(<["1", "2"]:(literal.(type))(); separator=", ">);
+        <type>[] sizeThree = iterable.toSizedArray(3);
+        Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "2", "0"]:(literal.(type))(); separator=", ">}, sizeThree)
+                || Arrays.equals(new <type>[]{<["2", "1", "0"]:(literal.(type))(); separator=", ">}, sizeThree)
+                || Arrays.equals(new <type>[]{<["0", "1", "2"]:(literal.(type))(); separator=", ">}, sizeThree)
+                || Arrays.equals(new <type>[]{<["0", "2", "1"]:(literal.(type))(); separator=", ">}, sizeThree)
+                || Arrays.equals(new <type>[]{<["2", "0", "1"]:(literal.(type))(); separator=", ">}, sizeThree)
+                || Arrays.equals(new <type>[]{<["1", "0", "2"]:(literal.(type))(); separator=", ">}, sizeThree));
+        <type>[] sizeTwo = iterable.toSizedArray(2);
+        Assert.assertTrue(Arrays.equals(new <type>[]{<["1", "2"]:(literal.(type))(); separator=", ">}, sizeTwo)
+                || Arrays.equals(new <type>[]{<["2", "1"]:(literal.(type))(); separator=", ">}, sizeTwo));
+        <type>[] sizeOne = iterable.toSizedArray(1);
+        Assert.assertTrue(Arrays.equals(new <type>[]{<["1"]:(literal.(type))(); separator=", ">}, sizeOne)
+                || Arrays.equals(new <type>[]{<["2"]:(literal.(type))(); separator=", ">}, sizeOne));
+        <type>[] sizeZero = iterable.toSizedArray(0);
+        Assert.assertTrue(Arrays.equals(new <type>[]{}, sizeZero));
+    }
+
+    @Test
     public void toArrayWithTargetArray()
     {
         <type>[] originalAsSortedArray = this.classUnderTest().toSortedArray();

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/immutable/primitive/ImmutableBooleanArrayList.java
@@ -87,6 +87,11 @@ final class ImmutableBooleanArrayList
         return new ImmutableBooleanArrayList(iterable.toArray());
     }
 
+    public static ImmutableBooleanArrayList newList(BooleanIterable iterable, int size)
+    {
+        return new ImmutableBooleanArrayList(iterable.toSizedArray(size));
+    }
+
     public static ImmutableBooleanArrayList newListWith(boolean... elements)
     {
         return new ImmutableBooleanArrayList(elements);
@@ -289,8 +294,15 @@ final class ImmutableBooleanArrayList
     @Override
     public boolean[] toArray()
     {
-        boolean[] newItems = new boolean[this.size];
-        for (int i = 0; i < this.size; i++)
+        return this.toSizedArray(this.size);
+    }
+
+    @Override
+    public boolean[] toSizedArray(int s)
+    {
+        boolean[] newItems = new boolean[s];
+        int newSize = Math.min(s, this.size);
+        for (int i = 0; i < newSize; i++)
         {
             newItems[i] = this.items.get(i);
         }

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/list/mutable/primitive/BooleanArrayList.java
@@ -797,8 +797,15 @@ public final class BooleanArrayList
     @Override
     public boolean[] toArray()
     {
-        boolean[] newItems = new boolean[this.size];
-        for (int i = 0; i < this.size; i++)
+        return this.toSizedArray(this.size);
+    }
+
+    @Override
+    public boolean[] toSizedArray(int s)
+    {
+        boolean[] newItems = new boolean[s];
+        int newSize = Math.min(s, this.size);
+        for (int i = 0; i < newSize; i++)
         {
             newItems[i] = this.items.get(i);
         }

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/collection/mutable/primitive/AbstractBooleanIterableTestCase.java
@@ -506,6 +506,19 @@ public abstract class AbstractBooleanIterableTestCase
     }
 
     @Test
+    public void toSizedArray()
+    {
+        assertEquals(0L, this.newWith().toSizedArray(0).length);
+        assertEquals(1L, this.newWith().toSizedArray(1).length);
+        assertEquals(0L, this.newWith(true).toSizedArray(0).length);
+        assertTrue(Arrays.equals(new boolean[]{true}, this.newWith(true).toSizedArray(1)));
+        assertTrue(Arrays.equals(new boolean[]{true, false}, this.newWith(true).toSizedArray(2))
+                || Arrays.equals(new boolean[]{false, true}, this.newWith(true).toSizedArray(2)));
+        assertTrue(Arrays.equals(new boolean[]{false, true}, this.newWith(true, false).toSizedArray(2))
+                || Arrays.equals(new boolean[]{true, false}, this.newWith(true, false).toSizedArray(2)));
+    }
+
+    @Test
     public void testEquals()
     {
         BooleanIterable iterable1 = this.newWith(true, false, true, false);


### PR DESCRIPTION
This PR attempts to fix a performance problem I found in immutablePrimitiveListFactoryImpl.stg for the `withAll(<primitive>Iterable)` method.

This method would call size at least three times on the primitive Iterables with a size > 1. For Lazy primitive Iterables, this will have the affect of iterating and applying procedures, functions, and predicates three times. The solution I have come up with is to add a toSizedArray(int size) method to primitive iterables that will target the contents of the iterables to the presized array. One of the things to open to discussion/debate is how to handle the situations where the size is < or > the size of the iterable. In the < case right now, I fill up to the size of the new array, and the rest of the iterable contents will be left off. In the  > case, I fill the array with all the contents of the iterable, and the new array is left with default initialized padded values in the remainder of the array.