### PR TITLE
Add basic Develocity integration and enable build caching

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,6 +31,8 @@ jobs:
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
       - name: Generate Coverage Report
         run: ./mvnw --color=always verify
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Archive Jacoco reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,10 +39,12 @@ jobs:
       - run: ./mvnw --color=always install -DskipTests=true
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Mutation Test
         run: mvn eu.stamp-project:pitmp-maven-plugin:run -DwithHistory -DtimeoutConstant=8000
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Archive pitest reports
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,7 @@ jobs:
       - run: ./mvnw --threads 2C --color=always verify
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -57,6 +58,7 @@ jobs:
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-enforcer-plugin -DskipTests
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -85,6 +87,7 @@ jobs:
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-dependency-plugin -DskipTests
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -117,6 +120,7 @@ jobs:
         run: ./mvnw --color=always verify
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -154,6 +158,7 @@ jobs:
         run: ./mvnw --color=always verify
         env:
           MAVEN_OPTS: '-Xmx2g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   acceptance-tests:
     name: Acceptance Tests
@@ -179,6 +184,7 @@ jobs:
       - run: ./mvnw --color=always install --projects acceptance-tests --also-make --activate-profiles all
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -207,6 +213,7 @@ jobs:
       - run: ./mvnw --color=always install --projects performance-tests --also-make --activate-profiles all -DskipTests=true
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -226,6 +233,7 @@ jobs:
         run: ./mvnw --color=always verify checkstyle:check --activate-profiles all -DskipTests=true
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
   javadoc:
     name: Javadoc 11
@@ -249,14 +257,18 @@ jobs:
           java-version: 11
       - name: Build Generator
         run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: JavaDoc Aggregate
         run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean javadoc:aggregate verify --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: JavaDoc Jar
         run: ./mvnw --color=always --activate-profiles maven-javadoc-plugin -DskipTests -Denforcer.skip=true clean verify javadoc:jar --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: '-Xmx1g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
 
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
@@ -292,10 +304,13 @@ jobs:
       - run: java --version
       - name: Build Generator
         run: ./mvnw --threads 2C --color=always -DskipTests install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: Javadoc
         run: ./mvnw --threads 2C --color=always --activate-profiles maven-javadoc-plugin -DskipTests javadoc:aggregate verify --projects '!unit-tests,!serialization-tests,!jcstress-tests,!unit-tests-java8,!test-coverage'
         env:
           MAVEN_OPTS: '-Xmx2g'
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - name: 'Clean Maven cache'
         run: rm -rf ~/.m2/repository/org/eclipse/collections
 

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ fabric.properties
 .project
 .settings/
 .classpath
+
+# Develocity
+.mvn/.develocity/develocity-workspace-id

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<develocity
+  xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <server>
+    <url>https://develocity-staging.eclipse.org</url>
+  </server>
+  <projectId>technology.collections</projectId>
+  <buildScan>
+    <obfuscation>
+      <ipAddresses>0.0.0.0</ipAddresses>
+    </obfuscation>
+    <publishing>
+      <onlyIf>
+        <![CDATA[authenticated]]>
+      </onlyIf>
+    </publishing>
+    <backgroundBuildScanUpload>#{isFalse(env['CI'])}</backgroundBuildScanUpload>
+  </buildScan>
+  <buildCache>
+    <local>
+      <enabled>#{isFalse(env['CI'])}</enabled>
+    </local>
+    <remote>
+      <enabled>true</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>develocity-maven-extension</artifactId>
+		<version>1.23.2</version>
+	</extension>
+	<extension>
+		<groupId>com.gradle</groupId>
+		<artifactId>common-custom-user-data-maven-extension</artifactId>
+		<version>2.0.1</version>
+	</extension>
+</extensions>


### PR DESCRIPTION
As one of the impactful Eclipse projects, we (the Develocity Solutions team) would like to invite you to be a part of the [Eclipse Develocity evaluation initiative](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html).

## Description
This PR publishes a build scan for every CI build and for every local build from an authenticated Eclipse committer. The build will not fail if publishing fails. Setting the access key env var was added in relevant CI pipelines, however, the secret will need to be set by Eclipse infra - you can initiate that by opening a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket.

The build scans of the Eclipse Collections project are published to the Develocity instance at [develocity-staging.eclipse.org](https://develocity-staging.eclipse.org), hosted by the Eclipse Foundation and run in partnership between the Eclipse and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Eclipse Collections project and all other Eclipse projects.

On this Develocity instance, the Eclipse Collections project will have access not only to all of the published build scans but also to other aggregate data features such as:

* Dashboards to view all historical build scans, along with performance [trends](https://develocity-staging.eclipse.org/scans/trends?search.relativeStartTime=P28D&trends.timeResolution=week) over time. For example, look at the [Quarkus instance trends dashboard](https://ge.quarkus.io/scans/trends?search.relativeStartTime=P28D&search.tags=ci&search.timeZoneId=Europe%2FLjubljana) with the `ci` filter applied.
* [Build failure analytics](https://develocity-staging.eclipse.org/scans/failures?search.relativeStartTime=P28D) for enhanced investigation and diagnosis of build failures. You can also explore the [Quarkus instance](https://ge.quarkus.io/scans/failures?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) for example of a different OSS projects Develocity instance.
* [Test failure analytics](https://develocity-staging.eclipse.org/scans/tests?search.relativeStartTime=P28D) to better understand trends and causes around slow, failing, and flaky tests. Going to the [Quarkus instance](https://ge.quarkus.io/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Europe%2FLjubljana) again, this will probably give you a better representation of the type of data available. You can also order it by flakiness, which is a good starting point when deciding which tests need fixing the most.

This will also enable you to (optionally) use build time optimization features, such as (remote) build caching and Predictive Test Selection. In this PR, build caching is enabled, with the local cache being disabled on CI and only allowing CI to write to the remote cache, as per the general recommendations.

I ran [some tests](https://github.com/ribafish/kotlinTests/actions/runs/13809242730) about build speed improvements when caching is configured with the following results. Here are the best-case (no code change) savings:

| Invocation | Build time without cache | Build time with cache | Build time savings |
|-----------|--------------------------|-----------------------|-------------------|
| ` install -DskipTests=true` | 2m 46.859s | 26.396s | 2m 20s (84%) | 
| `install` | 5m 5.385s |  2m 45.928s | 2m 19.457s (46%) |
| `verify checkstyle:check --activate-profiles all -DskipTests=true` | 4m 11.061s | 26.894s | 3m 44.167s (89%) |
| `install --projects performance-tests --also-make --activate-profiles all -DskipTests=true` | 1m 8.484s | 15.138s | 53.346s (77%) |

There are additional savings to be made when running `install` goal if the [runOrderRandomSeed](https://ge.solutions-team.gradle.com/c/xxzfwpgfzttqs/hkwb4k3sz2mng/goal-inputs?cacheability=cacheable) would be fixed, as that is an unstable goal input, because of which the cache key calculated differs, thus prevent the cache to get hits.


Caching can be tested without setting up the Develocity credentials - simply run 2 or more builds (the first one will fill the local cache, next ones can use it).

More information can be read in the [Eclipse announcement](https://www.eclipse.org/lists/cross-project-issues-dev/msg20000.html). 

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.

### IMPORTANT
**To get scans publishing on CI, a [helpdesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues) ticket needs to be opened in order for those credentials to be created, as explained in the [initiative documentation](https://gitlab.eclipse.org/eclipsefdn/it/releng/develocity/develocity-documentation#ci-integration).**

