### PR TITLE
Change Javadoc JDK to 8 to work around Deploy build problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
+                    <source>8</source>
                     <doctitle>Eclipse Collections - ${project.version}</doctitle>
                     <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                     <show>public</show>


### PR DESCRIPTION
See here: https://bugs.openjdk.org/browse/JDK-8212233