### PR TITLE
Upgrade minimum version to Java 17

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [11]
+        java-version: [17]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [11]
+        java-version: [17]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,11 +21,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - run: ./mvnw --threads 2C --color=always verify
         env:
           MAVEN_OPTS: '-Xmx1g'
@@ -47,11 +47,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Run maven-enforcer-plugin
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-enforcer-plugin -DskipTests
@@ -75,11 +75,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Run maven-dependency-plugin
         run: ./mvnw --threads 2C --color=always verify --activate-profiles maven-dependency-plugin -DskipTests
@@ -171,11 +171,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - run: ./mvnw --color=always install --projects acceptance-tests --also-make --activate-profiles all
         env:
           MAVEN_OPTS: '-Xmx1g'
@@ -199,11 +199,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - run: ./mvnw --color=always install --projects performance-tests --also-make --activate-profiles all -DskipTests=true
         env:
           MAVEN_OPTS: '-Xmx1g'
@@ -217,18 +217,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Checkstyle
         run: ./mvnw --color=always verify checkstyle:check --activate-profiles all -DskipTests=true
         env:
           MAVEN_OPTS: '-Xmx1g'
 
   javadoc:
-    name: Javadoc 11
+    name: Javadoc 17
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -242,11 +242,11 @@ jobs:
             maven-
 
       - run: mvn --non-recursive wrapper:wrapper -Dmaven=3.9.6
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Build Generator
         run: ./mvnw --color=always -Dsurefire.useFile=false -DskipTests -Denforcer.skip=true clean install --projects 'eclipse-collections-code-generator,eclipse-collections-code-generator-maven-plugin'
       - name: JavaDoc Aggregate

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,7 +39,7 @@
   <component name="ProjectResources">
     <default-html-doctype>http://www.w3.org/1999/xhtml</default-html-doctype>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
   <component name="SvnBranchConfigurationManager">

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>biz.aQute.bnd.annotation</artifactId>
-            <version>6.4.1</version>
+            <version>7.1.0</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/eclipse-collections-api/pom.xml
+++ b/eclipse-collections-api/pom.xml
@@ -133,12 +133,12 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections API - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections API - ${project.version}</windowtitle>
                             <show>public</show>
                             <links>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>none</doclint>

--- a/eclipse-collections-code-generator-maven-plugin/pom.xml
+++ b/eclipse-collections-code-generator-maven-plugin/pom.xml
@@ -172,12 +172,12 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                             <show>public</show>
                             <links>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>none</doclint>

--- a/eclipse-collections-code-generator/pom.xml
+++ b/eclipse-collections-code-generator/pom.xml
@@ -69,12 +69,12 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                             <show>public</show>
                             <links>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>none</doclint>

--- a/eclipse-collections-forkjoin/pom.xml
+++ b/eclipse-collections-forkjoin/pom.xml
@@ -115,7 +115,7 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections Fork Join Utilities - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections Fork Join Utilities - ${project.version}</windowtitle>
                             <show>public</show>

--- a/eclipse-collections-testutils/pom.xml
+++ b/eclipse-collections-testutils/pom.xml
@@ -120,12 +120,12 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections Test Utilities - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections Test Utilities - ${project.version}</windowtitle>
                             <show>public</show>
                             <links>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>none</doclint>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 		    <groupId>biz.aQute.bnd</groupId>
 		    <artifactId>biz.aQute.bnd.annotation</artifactId>
-		    <version>6.4.1</version>
+		    <version>7.1.0</version>
 		    <scope>provided</scope>
             <optional>true</optional>
 		</dependency>

--- a/eclipse-collections/pom.xml
+++ b/eclipse-collections/pom.xml
@@ -142,12 +142,12 @@
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                             <show>public</show>
                             <links>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>none</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
         <junit.version>4.13.2</junit.version>
         <jmh.version>1.37</jmh.version>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.fork>true</maven.compiler.fork>
         <maven.compiler.meminitial>2048m</maven.compiler.meminitial>
         <maven.compiler.maxmem>2048m</maven.compiler.maxmem>
@@ -531,14 +531,14 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
+                    <source>17</source>
                     <doctitle>Eclipse Collections - ${project.version}</doctitle>
                     <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                     <show>public</show>
-                    <detectJavaApiLink>false</detectJavaApiLink>
+                    <detectJavaApiLink>true</detectJavaApiLink>
                     <links>
                         <link>https://junit.org/junit4/javadoc/latest</link>
-                        <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                        <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                     </links>
                     <destDir>${project.version}</destDir>
                     <doclint>html,syntax,accessibility</doclint>
@@ -753,14 +753,14 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                             <show>public</show>
-                            <detectJavaApiLink>false</detectJavaApiLink>
+                            <detectJavaApiLink>true</detectJavaApiLink>
                             <links>
                                 <link>https://junit.org/junit4/javadoc/latest</link>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>html,syntax,accessibility</doclint>
@@ -819,7 +819,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                                     <rules>
                                         <dependencyConvergence />
                                         <requireJavaVersion>
-                                            <version>11</version>
+                                            <version>17</version>
                                         </requireJavaVersion>
                                         <requirePluginVersions>
                                             <banLatest>true</banLatest>
@@ -1142,14 +1142,14 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.11.2</version>
                         <configuration>
-                            <source>8</source>
+                            <source>17</source>
                             <doctitle>Eclipse Collections - ${project.version}</doctitle>
                             <windowtitle>Eclipse Collections - ${project.version}</windowtitle>
                             <show>public</show>
-                            <detectJavaApiLink>false</detectJavaApiLink>
+                            <detectJavaApiLink>true</detectJavaApiLink>
                             <links>
                                 <link>https://junit.org/junit4/javadoc/latest</link>
-                                <link>https://docs.oracle.com/en/java/javase/11/docs/api</link>
+                                <link>https://docs.oracle.com/en/java/javase/17/docs/api</link>
                             </links>
                             <destDir>${project.version}</destDir>
                             <doclint>html,syntax,accessibility</doclint>

--- a/pom.xml
+++ b/pom.xml
@@ -1085,7 +1085,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                     <plugin>
                         <groupId>biz.aQute.bnd</groupId>
                         <artifactId>bnd-maven-plugin</artifactId>
-                        <version>6.4.0</version>
+                        <version>7.1.0</version>
                         <executions>
                             <execution>
                                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
 
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.8.1</version>
                 </plugin>
 
                 <plugin>
@@ -1181,7 +1181,7 @@ Arrays, Maps or Strings. The iteration protocol was inspired by the Smalltalk co
                     <plugins>
                         <plugin>
                             <artifactId>maven-dependency-plugin</artifactId>
-                            <version>3.1.2</version>
+                            <version>3.8.1</version>
                             <configuration>
                                 <failOnWarning>true</failOnWarning>
                                 <ignoredUnusedDeclaredDependencies>

--- a/unit-tests-java8/pom.xml
+++ b/unit-tests-java8/pom.xml
@@ -54,6 +54,12 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Updating the minimum version of Eclipse Collections to Java 17. The Java 11 release build has failed due to the `Javadoc:jar` target not succeeding. This has been a known issue which was supposedly fixed but not successfully backported to Java 11. Reference OpenJDK ticket: https://bugs.openjdk.org/browse/JDK-8212233

Please note: If you refer to previous commits merged today, you can observe that all the mentioned solutions like `<source>8</source>` were tried. 

Example Release builds are here: https://ci.eclipse.org/collections/job/deploy/168/console

Logs for reference:
```
03:34:48:044 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:jar (attach-javadocs) on project eclipse-collections-code-generator: MavenReportException: Error while generating Javadoc: 
03:34:48:044 [ERROR] Exit code: 1
03:34:48:044 [ERROR] javadoc: error - The code being documented uses packages in the unnamed module, but the packages defined in https://docs.oracle.com/en/java/javase/11/docs/api/ are in named modules.
03:34:48:044 [ERROR] Command line was: /opt/tools/java/openjdk/jdk-11/11.0.2+9/bin/javadoc -J-Duser.language= -J-Duser.country= @options @packages
03:34:48:044 [ERROR] 
03:34:48:044 [ERROR] Refer to the generated Javadoc files in '/home/jenkins/agent/workspace/deploy/eclipse-collections-code-generator/target/reports/apidocs' dir.
03:34:48:044 [ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.11.2:jar (attach-javadocs) on project eclipse-collections-code-generator: MavenReportException: Error while generating Javadoc: 
Exit code: 1
javadoc: error - The code being documented uses packages in the unnamed module, but the packages defined in https://docs.oracle.com/en/java/javase/11/docs/api/ are in named modules.
Command line was: /opt/tools/java/openjdk/jdk-11/11.0.2+9/bin/javadoc -J-Duser.language= -J-Duser.country= @options @packages

```

As a result of all of these issues and JDK 11 being EOL since September 2023, it is the best option to upgrade Eclipse Collections to 17. Moreover, with JDK 25 going to be released in 3 months, it is opportune time to skip Java 11 version for Eclipse Collections and jump directly to Java 17.