### PR TITLE
 Fix Map.merge to handle null values without invoking remapping function

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMap.java
@@ -2358,7 +2358,7 @@ public final class ConcurrentHashMap<K, V>
                     if (candidate.equals(key))
                     {
                         V oldValue = e.getValue();
-                        V newValue = remappingFunction.apply(oldValue, value);
+                        V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
                         Entry<K, V> replacementChainForRemoval =
                                 this.createReplacementChainForRemoval((Entry<K, V>) o, e);
                         Entry<K, V> newEntry = newValue == null

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/ConcurrentHashMapUnsafe.java
@@ -2487,7 +2487,7 @@ public class ConcurrentHashMapUnsafe<K, V>
                     if (candidate.equals(key))
                     {
                         V oldValue = e.getValue();
-                        V newValue = remappingFunction.apply(oldValue, value);
+                        V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
                         Entry<K, V> replacementChainForRemoval = this.createReplacementChainForRemoval((Entry<K, V>) o, e);
                         Entry<K, V> newEntry = newValue == null
                                 ? replacementChainForRemoval

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -591,7 +591,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         }
         if (cur != CHAINED_KEY && this.nonNullTableObjectEquals(cur, key))
         {
-            V newValue = remappingFunction.apply((V) this.table[index + 1], value);
+            V oldValue = (V) this.table[index + 1];
+            V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
             this.table[index + 1] = newValue;
             if (newValue == null)
             {
@@ -622,7 +623,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
                 }
                 if (this.nonNullTableObjectEquals(chain[i], key))
                 {
-                    V newValue = remappingFunction.apply((V) chain[i + 1], value);
+                    V oldValue = (V) chain[i + 1];
+                    V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
                     if (newValue == null)
                     {
                         this.overwriteWithLastElementFromChain(chain, index, i);

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -641,7 +641,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         if (cur != CHAINED_KEY && this.nonNullTableObjectEquals(cur, key))
         {
             V oldValue = (V) this.table[index + 1];
-            V newValue = remappingFunction.apply(oldValue, value);
+            V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
             this.table[index + 1] = newValue;
             if (newValue == null)
             {
@@ -673,7 +673,7 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
                 if (this.nonNullTableObjectEquals(chain[i], key))
                 {
                     V oldValue = (V) chain[i + 1];
-                    V newValue = remappingFunction.apply(oldValue, value);
+                    V newValue = oldValue == null ? value : remappingFunction.apply(oldValue, value);
                     if (newValue == null)
                     {
                         this.overwriteWithLastElementFromChain(chain, index, i);

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MapTestCase.java
@@ -297,6 +297,17 @@ public interface MapTestCase
             throw new IllegalArgumentException();
         }));
         assertIterablesEqual(this.newWithKeysValues(1, "1", 2, "2Two", 4, "4", 5, "5"), map);
+
+        // existing key with null value, remapping function is not called and new value is used
+        if (this.supportsNullValues())
+        {
+            map.put(2, null);
+            String value5 = map.merge(2, "Two", (oldValue, newValue) -> {
+                fail("Should not be called for null value key. But was invoked for old value: " + oldValue + ", new value: " + newValue);
+                return null;
+            });
+            assertEquals("Two", value5);
+        }
     }
 
     class AlwaysEqual

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnifiedMapTest.java
@@ -38,6 +38,7 @@ import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ArrayIterate;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -877,6 +878,28 @@ public class UnifiedMapTest extends UnifiedMapTestCase
         assertNull(merge);
         MutableMap<Integer, Integer> expectedMap = MORE_COLLISIONS.subList(1, 8).toMap(k -> k, v -> v);
         assertEquals(expectedMap, actualMap);
+    }
+
+    @Test
+    public void mergeNullValue()
+    {
+        UnifiedMap<String, String> map = UnifiedMap.newMap();
+        map.put("nullKey", null);
+        assertDoesNotThrow(() -> map.merge("nullKey", "newValue", (oldValue, newValue) -> {
+            throw new IllegalStateException("Should not be called for null value key. But was invoked for old value: " + oldValue + ", new value: " + newValue);
+        }));
+        assertEquals("newValue", map.get("nullKey"));
+    }
+
+    @Test
+    public void mergeNullValueInMapWithCollisions()
+    {
+        MutableMap<Integer, Integer> map = this.mapWithCollisionsOfSize(8);
+        map.replaceAll((integer, integer2) -> null);
+        map.forEachKey(key -> map.merge(key, 42, (oldValue, newValue) -> {
+            throw new IllegalStateException("Should not be called for null value key. But was invoked for old value: " + oldValue + ", new value: " + newValue);
+        }));
+        map.forEachKey(key -> assertEquals(42, map.get(key)));
     }
 
     @Override


### PR DESCRIPTION
This PR updates Map.merge to correctly handle entries with null values by bypassing the remapping function and directly storing the provided value.
The change was introduced in PR #1542 and violates the optional Map.merge contract, deviating from the previous behavior of maps affected by mentioned PR.