### PR TITLE
Add SBOM generation and upload workflow

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,66 @@
+name: Generate Maven SBOM
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version"
+        default: "master"
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PRODUCT_PATH: './'
+  PLUGIN_VERSION: '2.7.8'
+  SBOM_TYPE: 'makeAggregateBom'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.version.outputs.PROJECT_VERSION }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "$PRODUCT_PATH/pom.xml"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'eclipse-collections'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'bom.json'
+      parentProject: 'cde09fc0-2d5c-4e7f-afa1-5c18e252b9ea'


### PR DESCRIPTION
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for the `eclipse-collections` product.

Currently the workflow is triggered by new releases being published. A cyclonedx maven plugin (`cyclonedx-maven-plugin`) is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/), under the `Eclipse Collections/eclipse-collections` entry. After a successful workflow run, to view the uploaded results, you can log into the instance by using your EF account credentials.

We have tested the SBOM generation separately and everything worked successfully. However, due to limited permissions and possibly incomplete knowledge of your release processes, if the changes get merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (for the version input the latest release tag can be used).  

An important mention to keep in mind for the `on release published` trigger, when the workflow runs the SBOM plugin will try to pull all new versions of internal dependencies from their respective publish locations. This means that for the SBOM generation to be successful, the newly released internal dependencies have to be published *before* the workflow run. From a quick historical look, this seems to already be the case. If the order of operations changes in the future, the change will have to be reflected in the workflow as well.

For any inconsistencies or potential integration issues with existing release processes that we might have missed, please feel free to update the workflow as needed, edits by maintainers are enabled. Additionally, if maintaining multiple parallel branches for releases, a version of the workflow should run on them as well.

Please let us know if you have any questions we can help with.

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html), alongside documentation on what is an SBOM, what are they used for, tooling ecosystem and our upload integration. Previous successful early adopters workflow examples are listed in the table at [SBOM Early Adopters](https://eclipse-csi.github.io/security-handbook/sbom/earlyadopters.html)