### PR TITLE
Fix updateValue exception safety in UnifiedMap and UnifiedMapWithHashingStrategy.

### DIFF
--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/mutable/UnifiedMap.java
@@ -424,8 +424,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         Object cur = this.table[index];
         if (cur == null)
         {
-            this.table[index] = UnifiedMap.toSentinelIfNull(key);
             V result = function.valueOf(factory.value());
+            this.table[index] = UnifiedMap.toSentinelIfNull(key);
             this.table[index + 1] = result;
             ++this.occupied;
             return result;
@@ -449,8 +449,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             {
                 if (chain[i] == null)
                 {
-                    chain[i] = UnifiedMap.toSentinelIfNull(key);
                     V result = function.valueOf(factory.value());
+                    chain[i] = UnifiedMap.toSentinelIfNull(key);
                     chain[i + 1] = result;
                     if (++this.occupied > this.maxSize)
                     {
@@ -468,9 +468,9 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             }
             Object[] newChain = new Object[chain.length + 4];
             System.arraycopy(chain, 0, newChain, 0, chain.length);
+            V result = function.valueOf(factory.value());
             this.table[index + 1] = newChain;
             newChain[chain.length] = UnifiedMap.toSentinelIfNull(key);
-            V result = function.valueOf(factory.value());
             newChain[chain.length + 1] = result;
             if (++this.occupied > this.maxSize)
             {
@@ -481,8 +481,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         Object[] newChain = new Object[4];
         newChain[0] = this.table[index];
         newChain[1] = this.table[index + 1];
-        newChain[2] = UnifiedMap.toSentinelIfNull(key);
         V result = function.valueOf(factory.value());
+        newChain[2] = UnifiedMap.toSentinelIfNull(key);
         newChain[3] = result;
         this.table[index] = CHAINED_KEY;
         this.table[index + 1] = newChain;
@@ -500,8 +500,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         Object cur = this.table[index];
         if (cur == null)
         {
-            this.table[index] = UnifiedMap.toSentinelIfNull(key);
             V result = function.value(factory.value(), parameter);
+            this.table[index] = UnifiedMap.toSentinelIfNull(key);
             this.table[index + 1] = result;
             ++this.occupied;
             return result;
@@ -530,8 +530,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             {
                 if (chain[i] == null)
                 {
-                    chain[i] = UnifiedMap.toSentinelIfNull(key);
                     V result = function.value(factory.value(), parameter);
+                    chain[i] = UnifiedMap.toSentinelIfNull(key);
                     chain[i + 1] = result;
                     if (++this.occupied > this.maxSize)
                     {
@@ -549,9 +549,9 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
             }
             Object[] newChain = new Object[chain.length + 4];
             System.arraycopy(chain, 0, newChain, 0, chain.length);
+            V result = function.value(factory.value(), parameter);
             this.table[index + 1] = newChain;
             newChain[chain.length] = UnifiedMap.toSentinelIfNull(key);
-            V result = function.value(factory.value(), parameter);
             newChain[chain.length + 1] = result;
             if (++this.occupied > this.maxSize)
             {
@@ -562,8 +562,8 @@ public class UnifiedMap<K, V> extends AbstractMutableMap<K, V>
         Object[] newChain = new Object[4];
         newChain[0] = this.table[index];
         newChain[1] = this.table[index + 1];
-        newChain[2] = UnifiedMap.toSentinelIfNull(key);
         V result = function.value(factory.value(), parameter);
+        newChain[2] = UnifiedMap.toSentinelIfNull(key);
         newChain[3] = result;
         this.table[index] = CHAINED_KEY;
         this.table[index + 1] = newChain;

--- a/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
+++ b/eclipse-collections/src/main/java/org/eclipse/collections/impl/map/strategy/mutable/UnifiedMapWithHashingStrategy.java
@@ -473,8 +473,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         Object cur = this.table[index];
         if (cur == null)
         {
-            this.table[index] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
             V result = function.valueOf(factory.value());
+            this.table[index] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
             this.table[index + 1] = result;
             ++this.occupied;
             return result;
@@ -498,8 +498,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             {
                 if (chain[i] == null)
                 {
-                    chain[i] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
                     V result = function.valueOf(factory.value());
+                    chain[i] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
                     chain[i + 1] = result;
                     if (++this.occupied > this.maxSize)
                     {
@@ -517,9 +517,9 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             }
             Object[] newChain = new Object[chain.length + 4];
             System.arraycopy(chain, 0, newChain, 0, chain.length);
+            V result = function.valueOf(factory.value());
             this.table[index + 1] = newChain;
             newChain[chain.length] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
-            V result = function.valueOf(factory.value());
             newChain[chain.length + 1] = result;
             if (++this.occupied > this.maxSize)
             {
@@ -530,8 +530,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         Object[] newChain = new Object[4];
         newChain[0] = this.table[index];
         newChain[1] = this.table[index + 1];
-        newChain[2] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
         V result = function.valueOf(factory.value());
+        newChain[2] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
         newChain[3] = result;
         this.table[index] = CHAINED_KEY;
         this.table[index + 1] = newChain;
@@ -549,8 +549,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         Object cur = this.table[index];
         if (cur == null)
         {
-            this.table[index] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
             V result = function.value(factory.value(), parameter);
+            this.table[index] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
             this.table[index + 1] = result;
             ++this.occupied;
             return result;
@@ -579,8 +579,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             {
                 if (chain[i] == null)
                 {
-                    chain[i] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
                     V result = function.value(factory.value(), parameter);
+                    chain[i] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
                     chain[i + 1] = result;
                     if (++this.occupied > this.maxSize)
                     {
@@ -598,9 +598,9 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
             }
             Object[] newChain = new Object[chain.length + 4];
             System.arraycopy(chain, 0, newChain, 0, chain.length);
+            V result = function.value(factory.value(), parameter);
             this.table[index + 1] = newChain;
             newChain[chain.length] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
-            V result = function.value(factory.value(), parameter);
             newChain[chain.length + 1] = result;
             if (++this.occupied > this.maxSize)
             {
@@ -611,8 +611,8 @@ public class UnifiedMapWithHashingStrategy<K, V> extends AbstractMutableMap<K, V
         Object[] newChain = new Object[4];
         newChain[0] = this.table[index];
         newChain[1] = this.table[index + 1];
-        newChain[2] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
         V result = function.value(factory.value(), parameter);
+        newChain[2] = UnifiedMapWithHashingStrategy.toSentinelIfNull(key);
         newChain[3] = result;
         this.table[index] = CHAINED_KEY;
         this.table[index + 1] = newChain;

--- a/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests-java8/src/test/java/org/eclipse/collections/test/map/mutable/MutableMapIterableTestCase.java
@@ -260,6 +260,43 @@ public interface MutableMapIterableTestCase extends MapIterableTestCase, MapTest
                 Bags.mutable.withAll(map4.values()).toStringOfItemToCount(),
                 Collections.nCopies(1000, 2),
                 map4.values());
+
+        MutableMapIterable<Integer, Integer> map5 = this.newWithKeysValues(1, 1, 2, 2, 3, 3);
+        RuntimeException factoryException = new RuntimeException("Factory exception");
+        RuntimeException functionException = new RuntimeException("Function exception");
+
+        RuntimeException actualException1 = assertThrows(
+                RuntimeException.class,
+                () -> map5.updateValue(4, () -> { throw factoryException; }, v -> v + 1));
+        assertSame(factoryException, actualException1);
+        assertIterablesEqual(this.newWithKeysValues(1, 1, 2, 2, 3, 3), map5);
+        assertFalse(map5.containsKey(4));
+        assertEquals(3, map5.size());
+
+        RuntimeException actualException2 = assertThrows(
+                RuntimeException.class,
+                () -> map5.updateValue(2, () -> 0, v -> { throw functionException; }));
+        assertSame(functionException, actualException2);
+        assertIterablesEqual(this.newWithKeysValues(1, 1, 2, 2, 3, 3), map5);
+        assertEquals(Integer.valueOf(2), map5.get(2));
+        assertEquals(3, map5.size());
+
+        MutableMapIterable<Integer, Integer> map6 = this.newWithKeysValues(1, 1, 2, 2, 3, 3);
+        RuntimeException actualException3 = assertThrows(
+                RuntimeException.class,
+                () -> map6.updateValueWith(4, () -> { throw factoryException; }, (v, p) -> v + 1, "param"));
+        assertSame(factoryException, actualException3);
+        assertIterablesEqual(this.newWithKeysValues(1, 1, 2, 2, 3, 3), map6);
+        assertFalse(map6.containsKey(4));
+        assertEquals(3, map6.size());
+
+        RuntimeException actualException4 = assertThrows(
+                RuntimeException.class,
+                () -> map6.updateValueWith(2, () -> 0, (v, p) -> { throw functionException; }, "param"));
+        assertSame(functionException, actualException4);
+        assertIterablesEqual(this.newWithKeysValues(1, 1, 2, 2, 3, 3), map6);
+        assertEquals(Integer.valueOf(2), map6.get(2));
+        assertEquals(3, map6.size());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/bimap/mutable/UnmodifiableBiMapTest.java
@@ -319,6 +319,17 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
     public void updateValue()
     {
         assertThrows(UnsupportedOperationException.class, () -> this.newMapWithKeysValues("key1", "value1", "key2", "value2").updateValue("key1", () -> "value3", String::toUpperCase));
+
+        MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValue(4, () -> 4, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertFalse(map.containsKey(4));
+        assertEquals(3, map.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValue(2, () -> 0, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertEquals(Integer.valueOf(2), map.get(2));
+        assertEquals(3, map.size());
     }
 
     @Override
@@ -330,6 +341,17 @@ public class UnmodifiableBiMapTest extends AbstractMutableBiMapTestCase
                 ? Character.toUpperCase(character)
                 : Character.toLowerCase(character);
         assertThrows(UnsupportedOperationException.class, () -> biMap.updateValueWith(4, () -> 'd', toUpperOrLowerCase, true));
+
+        MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValueWith(4, () -> 4, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertFalse(map.containsKey(4));
+        assertEquals(3, map.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValueWith(2, () -> 0, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertEquals(Integer.valueOf(2), map.get(2));
+        assertEquals(3, map.size());
     }
 
     @Override

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/MutableMapIterableTestCase.java
@@ -804,6 +804,26 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         Iterate.forEach(Interval.oneTo(1000), each -> map.updateValue(each % 10, () -> 0, integer -> integer + 1));
         assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
         assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
+
+        MutableMapIterable<Integer, Integer> map2 = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        RuntimeException factoryException = new RuntimeException("Factory exception");
+        RuntimeException functionException = new RuntimeException("Function exception");
+
+        RuntimeException actualException1 = assertThrows(
+                RuntimeException.class,
+                () -> map2.updateValue(4, () -> { throw factoryException; }, v -> v + 1));
+        assertSame(factoryException, actualException1);
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertFalse(map2.containsKey(4));
+        assertEquals(3, map2.size());
+
+        RuntimeException actualException2 = assertThrows(
+                RuntimeException.class,
+                () -> map2.updateValue(2, () -> 0, v -> { throw functionException; }));
+        assertSame(functionException, actualException2);
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertEquals(Integer.valueOf(2), map2.get(2));
+        assertEquals(3, map2.size());
     }
 
     @Test
@@ -830,6 +850,26 @@ public abstract class MutableMapIterableTestCase extends MapIterableTestCase
         }, "test"));
         assertEquals(Interval.zeroTo(9).toSet(), map.keySet());
         assertEquals(FastList.newList(Collections.nCopies(10, 100)), FastList.newList(map.values()));
+
+        MutableMapIterable<Integer, Integer> map2 = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        RuntimeException factoryException = new RuntimeException("Factory exception");
+        RuntimeException functionException = new RuntimeException("Function exception");
+
+        RuntimeException actualException1 = assertThrows(
+                RuntimeException.class,
+                () -> map2.updateValueWith(4, () -> { throw factoryException; }, (v, p) -> v + 1, "param"));
+        assertSame(factoryException, actualException1);
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertFalse(map2.containsKey(4));
+        assertEquals(3, map2.size());
+
+        RuntimeException actualException2 = assertThrows(
+                RuntimeException.class,
+                () -> map2.updateValueWith(2, () -> 0, (v, p) -> { throw functionException; }, "param"));
+        assertSame(functionException, actualException2);
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertEquals(Integer.valueOf(2), map2.get(2));
+        assertEquals(3, map2.size());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/mutable/UnmodifiableMutableMapTest.java
@@ -14,6 +14,7 @@ import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.ImmutableEntry;
@@ -22,6 +23,7 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -457,6 +459,17 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void updateValue()
     {
         assertThrows(UnsupportedOperationException.class, () -> this.<Integer, Integer>newMap().updateValue(0, () -> 0, Functions.identity()));
+
+        MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValue(4, () -> 4, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertFalse(map.containsKey(4));
+        assertEquals(3, map.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValue(2, () -> 0, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertEquals(Integer.valueOf(2), map.get(2));
+        assertEquals(3, map.size());
     }
 
     @Test
@@ -471,6 +484,17 @@ public class UnmodifiableMutableMapTest extends MutableMapTestCase
     public void updateValueWith()
     {
         assertThrows(UnsupportedOperationException.class, () -> this.<Integer, Integer>newMap().updateValueWith(0, () -> 0, (integer, parameter) -> 0, "test"));
+
+        MutableMapIterable<Integer, Integer> map = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValueWith(4, () -> 4, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertFalse(map.containsKey(4));
+        assertEquals(3, map.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map.updateValueWith(2, () -> 0, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map);
+        assertEquals(Integer.valueOf(2), map.get(2));
+        assertEquals(3, map.size());
     }
 
     @Test

--- a/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
+++ b/unit-tests/src/test/java/org/eclipse/collections/impl/map/sorted/mutable/UnmodifiableTreeMapTest.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMapIterable;
 import org.eclipse.collections.api.map.sorted.MutableSortedMap;
 import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.block.function.PassThruFunction0;
@@ -25,6 +26,7 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -587,6 +589,17 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> map.updateValue(0, () -> 0, Functions.identity()));
+
+        MutableMapIterable<Integer, Integer> map2 = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map2.updateValue(4, () -> 4, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertFalse(map2.containsKey(4));
+        assertEquals(3, map2.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map2.updateValue(2, () -> 0, v -> v + 1));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertEquals(Integer.valueOf(2), map2.get(2));
+        assertEquals(3, map2.size());
     }
 
     @Test
@@ -607,6 +620,17 @@ public class UnmodifiableTreeMapTest extends MutableSortedMapTestCase
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> map.updateValueWith(0, () -> 0, (integer, parameter) -> 0, "test"));
+
+        MutableMapIterable<Integer, Integer> map2 = this.newMapWithKeysValues(1, 1, 2, 2, 3, 3);
+        assertThrows(UnsupportedOperationException.class, () -> map2.updateValueWith(4, () -> 4, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertFalse(map2.containsKey(4));
+        assertEquals(3, map2.size());
+
+        assertThrows(UnsupportedOperationException.class, () -> map2.updateValueWith(2, () -> 0, (v, p) -> v + 1, "param"));
+        assertEquals(this.newMapWithKeysValues(1, 1, 2, 2, 3, 3), map2);
+        assertEquals(Integer.valueOf(2), map2.get(2));
+        assertEquals(3, map2.size());
     }
 
     @Test


### PR DESCRIPTION
I have a branch where I've added a bunch of tests and most of them pass, but it turns out that updateValue() and updateValueWith() actually have the bug so I figured I'd fix it first.