### PR TITLE
Category annotations

### DIFF
--- a/RELEASE_NOTE_DRAFT.md
+++ b/RELEASE_NOTE_DRAFT.md
@@ -8,6 +8,11 @@
 
 ## Documentation Changes
 * Improved Javadoc for 'Sets' factory class ([#782](https://github.com/eclipse-collections/eclipse-collections/issues/782))
+* Rewritten the category index for `RichIterable` to match the new categories and order
+
+## API Changes
+* Added category annotations package
+* Added category annotations to `RichIterable` and sorted methods in each category by name and parameters
 
 13.0.0
 ====================

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/RichIterable.java
@@ -27,6 +27,15 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.eclipse.collections.api.annotation.category.Aggregating;
+import org.eclipse.collections.api.annotation.category.Converting;
+import org.eclipse.collections.api.annotation.category.Counting;
+import org.eclipse.collections.api.annotation.category.Filtering;
+import org.eclipse.collections.api.annotation.category.Finding;
+import org.eclipse.collections.api.annotation.category.Grouping;
+import org.eclipse.collections.api.annotation.category.Iterating;
+import org.eclipse.collections.api.annotation.category.Testing;
+import org.eclipse.collections.api.annotation.category.Transforming;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.bag.MutableBag;
@@ -110,8 +119,10 @@ import org.eclipse.collections.api.tuple.Pair;
  * </ul></li>
  * <li><b>Counting 🔢</b>
  * <ul><li>
- * {@link #count(Predicate)} , {@link #countBy(Function)} , {@link #countByEach(Function)},
- * {@link #countByWith(Function2, Object)}, {@link #countWith(Predicate2, Object)} , {@link #size()}
+ * {@link #count(Predicate)} , {@link #countBy(Function)} , {@link #countBy(Function, MutableBagIterable)} ,
+ * {@link #countByEach(Function)} , {@link #countByEach(Function, MutableBagIterable)} ,
+ * {@link #countByWith(Function2, Object)} , {@link #countByWith(Function2, Object, MutableBagIterable)} ,
+ * {@link #countWith(Predicate2, Object)} , {@link #size()}
  * </li></ul>
  * <li><b>Testing 🧪</b>
  * <ul><li>
@@ -126,63 +137,87 @@ import org.eclipse.collections.api.tuple.Pair;
  * </li></ul>
  * <li><b>Finding 🔎</b>
  * <ul><li>
- * {@link #detect(Predicate)}, {@link #detectIfNone(Predicate, Function0)} ,
+ * {@link #detect(Predicate)}, {@link #detectIfNone(Predicate, Function0)}, {@link #detectOptional(Predicate)},
  * {@link #detectWith(Predicate2, Object)}, {@link #detectWithIfNone(Predicate2, Object, Function0)},
- * {@link #detectOptional(Predicate)}, {@link #detectWithOptional(Predicate2, Object)},
- * {@link #getAny()}, {@link #getFirst()}, {@link #getLast()}, {@link #getOnly()},
- * {@link #min()}, {@link #max()},
- * {@link #minBy(Function)}, {@link #minByOptional(Function)}, {@link #minOptional()}
- * {@link #maxBy(Function)}, {@link #maxByOptional(Function)}, {@link #maxOptional()}
+ * {@link #detectWithOptional(Predicate2, Object)}, {@link #getAny()}, {@link #getFirst()}, {@link #getLast()},
+ * {@link #getOnly()}, {@link #max()}, {@link #max(Comparator)}, {@link #maxBy(Function)},
+ * {@link #maxByOptional(Function)}, {@link #maxOptional()}, {@link #maxOptional(Comparator)},
+ * {@link #min()}, {@link #min(Comparator)}, {@link #minBy(Function)}, {@link #minByOptional(Function)},
+ * {@link #minOptional()}, {@link #minOptional(Comparator)}
  * </li></ul>
  * <li><b>Filtering 🚰</b>
  * <ul><li>
- * {@link #select(Predicate)}, {@link #selectInstancesOf(Class)}, {@link #selectWith(Predicate2, Object)},
- * {@link #reject(Predicate)}, {@link #rejectWith(Predicate2, Object)} ,
- * {@link #partition(Predicate)}, {@link #partitionWith(Predicate2, Object)}
+ * {@link #partition(Predicate)}, {@link #partitionWith(Predicate2, Object)}, {@link #reject(Predicate)},
+ * {@link #reject(Predicate, Collection)}, {@link #rejectWith(Predicate2, Object)},
+ * {@link #rejectWith(Predicate2, Object, Collection)}, {@link #select(Predicate)},
+ * {@link #select(Predicate, Collection)}, {@link #selectInstancesOf(Class)}, {@link #selectWith(Predicate2, Object)},
+ * {@link #selectWith(Predicate2, Object, Collection)}
  * </li></ul>
  * <li><b>Transforming 🦋</b>
  * <ul><li>
- * {@link #collect(Function)}, {@link #collectIf(Predicate, Function)}, {@link #collectWith(Function2, Object)},
- * {@link #collectBoolean(BooleanFunction)}, {@link #collectByte(ByteFunction)}, {@link #collectChar(CharFunction)},
- * {@link #collectDouble(DoubleFunction)}, {@link #collectFloat(FloatFunction)}, {@link #collectInt(IntFunction)},
- * {@link #collectLong(LongFunction)}, {@link #collectShort(ShortFunction)},
- * {@link #flatCollect(Function)}, {@link #flatCollectWith(Function2, Object)},
- * {@link #flatCollectBoolean(Function, MutableBooleanCollection)}, {@link #flatCollectByte(Function, MutableByteCollection)} ,
- * {@link #flatCollectChar(Function, MutableCharCollection)}, {@link #flatCollectDouble(Function, MutableDoubleCollection)} ,
- * {@link #flatCollectFloat(Function, MutableFloatCollection)}, {@link #flatCollectInt(Function, MutableIntCollection)} ,
- * {@link #flatCollectLong(Function, MutableLongCollection)}, {@link #flatCollectShort(Function, MutableShortCollection)} ,
- * {@link #zip(Iterable)}, {@link #zipWithIndex(Collection)}
+ * {@link #collect(Function)}, {@link #collect(Function, Collection)}, {@link #collectBoolean(BooleanFunction)},
+ * {@link #collectBoolean(BooleanFunction, MutableBooleanCollection)}, {@link #collectByte(ByteFunction)},
+ * {@link #collectByte(ByteFunction, MutableByteCollection)}, {@link #collectChar(CharFunction)},
+ * {@link #collectChar(CharFunction, MutableCharCollection)}, {@link #collectDouble(DoubleFunction)},
+ * {@link #collectDouble(DoubleFunction, MutableDoubleCollection)}, {@link #collectFloat(FloatFunction)},
+ * {@link #collectFloat(FloatFunction, MutableFloatCollection)}, {@link #collectIf(Predicate, Function)},
+ * {@link #collectIf(Predicate, Function, Collection)}, {@link #collectInt(IntFunction)},
+ * {@link #collectInt(IntFunction, MutableIntCollection)}, {@link #collectLong(LongFunction)},
+ * {@link #collectLong(LongFunction, MutableLongCollection)}, {@link #collectShort(ShortFunction)},
+ * {@link #collectShort(ShortFunction, MutableShortCollection)}, {@link #collectWith(Function2, Object)},
+ * {@link #collectWith(Function2, Object, Collection)}, {@link #flatCollect(Function)},
+ * {@link #flatCollect(Function, Collection)}, {@link #flatCollectBoolean(Function, MutableBooleanCollection)},
+ * {@link #flatCollectByte(Function, MutableByteCollection)}, {@link #flatCollectChar(Function, MutableCharCollection)},
+ * {@link #flatCollectDouble(Function, MutableDoubleCollection)},
+ * {@link #flatCollectFloat(Function, MutableFloatCollection)}, {@link #flatCollectInt(Function, MutableIntCollection)},
+ * {@link #flatCollectLong(Function, MutableLongCollection)},
+ * {@link #flatCollectShort(Function, MutableShortCollection)}, {@link #flatCollectWith(Function2, Object)},
+ * {@link #flatCollectWith(Function2, Object, Collection)}, {@link #zip(Iterable)}, {@link #zip(Iterable, Collection)},
+ * {@link #zipWithIndex()}, {@link #zipWithIndex(Collection)}
  * </li></ul>
  * <li><b>Grouping 🏘️</b>
  * <ul><li>
- * {@link #chunk(int)} , {@link #groupBy(Function)} , {@link #groupByAndCollect(Function, Function, MutableMultimap)} ,
- * {@link #groupByEach(Function)} , {@link #groupByUniqueKey(Function)}
+ * {@link #chunk(int)} , {@link #groupBy(Function)} , {@link #groupBy(Function, MutableMultimap)} ,
+ * {@link #groupByAndCollect(Function, Function, MutableMultimap)} , {@link #groupByEach(Function)} ,
+ * {@link #groupByEach(Function, MutableMultimap)} , {@link #groupByUniqueKey(Function)} ,
+ * {@link #groupByUniqueKey(Function, MutableMapIterable)}
  * </li></ul>
  * <li><b>Aggregating 📊</b>
  * <ul><li>
- * {@link #aggregateBy(Function, Function0, Function2)} , {@link #aggregateInPlaceBy(Function, Function0, Procedure2)} ,
- * {@link #injectInto(Object, Function2)} ,
- * {@link #injectIntoDouble(double, DoubleObjectToDoubleFunction)} ,
- * {@link #injectIntoFloat(float, FloatObjectToFloatFunction)} , {@link #injectIntoInt(int, IntObjectToIntFunction)} ,
- * {@link #injectIntoLong(long, LongObjectToLongFunction)} ,
- * {@link #reduce(BinaryOperator)}, {@link #reduceBy(Function, Function2)}, {@link #reduceInPlace(Collector)} ,
- * {@link #sumByDouble(Function, DoubleFunction)} , {@link #sumByFloat(Function, FloatFunction)} ,
- * {@link #sumByInt(Function, IntFunction)} , {@link #sumByLong(Function, LongFunction)} ,
- * {@link #sumOfDouble(DoubleFunction)}, {@link #sumOfFloat(FloatFunction)}, {@link #sumOfInt(IntFunction)}, {@link #sumOfLong(LongFunction)} ,
- * {@link #summarizeDouble(DoubleFunction)}, {@link #summarizeFloat(FloatFunction)},
+ * {@link #aggregateBy(Function, Function0, Function2)},
+ * {@link #aggregateBy(Function, Function0, Function2, MutableMapIterable)},
+ * {@link #aggregateInPlaceBy(Function, Function0, Procedure2)}, {@link #injectInto(Object, Function2)},
+ * {@link #injectInto(double, DoubleObjectToDoubleFunction)}, {@link #injectInto(float, FloatObjectToFloatFunction)},
+ * {@link #injectInto(int, IntObjectToIntFunction)}, {@link #injectInto(long, LongObjectToLongFunction)},
+ * {@link #injectIntoDouble(double, DoubleObjectToDoubleFunction)},
+ * {@link #injectIntoFloat(float, FloatObjectToFloatFunction)}, {@link #injectIntoInt(int, IntObjectToIntFunction)},
+ * {@link #injectIntoLong(long, LongObjectToLongFunction)}, {@link #reduce(BinaryOperator)},
+ * {@link #reduceBy(Function, Function2)}, {@link #reduceBy(Function, Function2, MutableMapIterable)},
+ * {@link #reduceInPlace(Collector)}, {@link #reduceInPlace(Supplier, BiConsumer)},
+ * {@link #sumByDouble(Function, DoubleFunction)}, {@link #sumByFloat(Function, FloatFunction)},
+ * {@link #sumByInt(Function, IntFunction)}, {@link #sumByLong(Function, LongFunction)},
+ * {@link #sumOfDouble(DoubleFunction)}, {@link #sumOfFloat(FloatFunction)}, {@link #sumOfInt(IntFunction)},
+ * {@link #sumOfLong(LongFunction)}, {@link #summarizeDouble(DoubleFunction)}, {@link #summarizeFloat(FloatFunction)},
  * {@link #summarizeInt(IntFunction)}, {@link #summarizeLong(LongFunction)}
  * </li></ul>
  * <li><b>Converting 🔌</b>
  * <ul><li>
- * {@link #into(Collection)}, {@link #appendString(Appendable)}, {@link #makeString()}, {@link #toString()},
- * {@link #toArray()}, {@link #toBag()}, {@link #toBiMap(Function, Function)}, {@link #toList()} ,
- * {@link #toMap(Function, Function)}, {@link #toSet()}, {@link #toSortedBag()}, {@link #toSortedBagBy(Function)},
- * {@link #toSortedList()}, {@link #toSortedListBy(Function)}, {@link #toSortedMap(Function, Function)},
- * {@link #toSortedMapBy(Function, Function, Function)}, {@link #toSortedSet()}, {@link #toSortedSetBy(Function)},
- * {@link #toImmutableBag()}, {@link #toImmutableBiMap(Function, Function)}, {@link #toImmutableList()},
- * {@link #toImmutableMap(Function, Function)}, {@link #toImmutableSet()},
- * {@link #toImmutableSortedBag()}, {@link #toImmutableSortedBagBy(Function)}, {@link #toImmutableSortedList()},
- * {@link #toImmutableSortedListBy(Function)} , {@link #toImmutableSortedSet()} , {@link #toImmutableSortedSetBy(Function)}
+ * {@link #appendString(Appendable)}, {@link #appendString(Appendable, String)},
+ * {@link #appendString(Appendable, String, String, String)}, {@link #into(Collection)}, {@link #makeString()},
+ * {@link #makeString(Function, String, String, String)}, {@link #makeString(String)},
+ * {@link #makeString(String, String, String)}, {@link #toArray()}, {@link #toArray(Object[])}, {@link #toBag()},
+ * {@link #toBiMap(Function, Function)}, {@link #toImmutableBag()}, {@link #toImmutableBiMap(Function, Function)},
+ * {@link #toImmutableList()}, {@link #toImmutableMap(Function, Function)}, {@link #toImmutableSet()},
+ * {@link #toImmutableSortedBag()}, {@link #toImmutableSortedBag(Comparator)}, {@link #toImmutableSortedBagBy(Function)},
+ * {@link #toImmutableSortedList()}, {@link #toImmutableSortedList(Comparator)},
+ * {@link #toImmutableSortedListBy(Function)}, {@link #toImmutableSortedSet()},
+ * {@link #toImmutableSortedSet(Comparator)}, {@link #toImmutableSortedSetBy(Function)}, {@link #toList()},
+ * {@link #toMap(Function, Function)}, {@link #toMap(Function, Function, Map)}, {@link #toSet()}, {@link #toSortedBag()},
+ * {@link #toSortedBag(Comparator)}, {@link #toSortedBagBy(Function)}, {@link #toSortedList()},
+ * {@link #toSortedList(Comparator)}, {@link #toSortedListBy(Function)},
+ * {@link #toSortedMap(Comparator, Function, Function)}, {@link #toSortedMap(Function, Function)},
+ * {@link #toSortedMapBy(Function, Function, Function)}, {@link #toSortedSet()}, {@link #toSortedSet(Comparator)},
+ * {@link #toSortedSetBy(Function)}, {@link #toString()}
  * </li></ul>
  * </ul>
  *
@@ -195,6 +230,7 @@ public interface RichIterable<T>
     //region [Category: Iterating] 🔄
 
     @Override
+    @Iterating
     default void forEach(Procedure<? super T> procedure)
     {
         this.each(procedure);
@@ -215,6 +251,7 @@ public interface RichIterable<T>
      * @since 6.0
      */
     @SuppressWarnings("UnnecessaryFullyQualifiedName")
+    @Iterating
     void each(Procedure<? super T> procedure);
 
     /**
@@ -230,6 +267,7 @@ public interface RichIterable<T>
      * @see #forEach(Procedure)
      * @since 6.0
      */
+    @Iterating
     RichIterable<T> tap(Procedure<? super T> procedure);
 
     /**
@@ -237,6 +275,7 @@ public interface RichIterable<T>
      *
      * @since 1.0.
      */
+    @Iterating
     LazyIterable<T> asLazy();
 
     //endregion [Category: Iterating] 🔄
@@ -248,6 +287,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Counting
     int size();
 
     /**
@@ -261,6 +301,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Counting
     int count(Predicate<? super T> predicate);
 
     /**
@@ -270,6 +311,7 @@ public interface RichIterable<T>
      * return lastNames.<b>countWith</b>(Predicates2.equal(), "Smith");
      * </pre>
      */
+    @Counting
     <P> int countWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -278,6 +320,7 @@ public interface RichIterable<T>
      *
      * @since 9.0
      */
+    @Counting
     default <V> Bag<V> countBy(Function<? super T, ? extends V> function)
     {
         return this.countBy(function, Bags.mutable.empty());
@@ -289,6 +332,7 @@ public interface RichIterable<T>
      *
      * @since 9.0
      */
+    @Counting
     default <V, R extends MutableBagIterable<V>> R countBy(Function<? super T, ? extends V> function, R target)
     {
         return this.collect(function, target);
@@ -300,6 +344,7 @@ public interface RichIterable<T>
      *
      * @since 9.0
      */
+    @Counting
     default <V, P> Bag<V> countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter)
     {
         return this.countByWith(function, parameter, Bags.mutable.empty());
@@ -311,6 +356,7 @@ public interface RichIterable<T>
      *
      * @since 9.0
      */
+    @Counting
     default <V, P, R extends MutableBagIterable<V>> R countByWith(Function2<? super T, ? super P, ? extends V> function, P parameter, R target)
     {
         return this.collectWith(function, parameter, target);
@@ -322,6 +368,7 @@ public interface RichIterable<T>
      *
      * @since 10.0.0
      */
+    @Counting
     default <V> Bag<V> countByEach(Function<? super T, ? extends Iterable<V>> function)
     {
         return this.asLazy().flatCollect(function).toBag();
@@ -333,6 +380,7 @@ public interface RichIterable<T>
      *
      * @since 10.0.0
      */
+    @Counting
     default <V, R extends MutableBagIterable<V>> R countByEach(Function<? super T, ? extends Iterable<V>> function, R target)
     {
         return this.flatCollect(function, target);
@@ -347,6 +395,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean isEmpty();
 
     /**
@@ -354,6 +403,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     default boolean notEmpty()
     {
         return !this.isEmpty();
@@ -364,6 +414,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean contains(Object object);
 
     /**
@@ -372,6 +423,7 @@ public interface RichIterable<T>
      *
      * @since 10.3
      */
+    @Testing
     default <V> boolean containsBy(
             Function<? super T, ? extends V> function,
             V value)
@@ -385,6 +437,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Testing
     default boolean containsAny(Collection<?> source)
     {
         return source instanceof RichIterable ? this.containsAnyIterable(source)
@@ -396,6 +449,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Testing
     default boolean containsNone(Collection<?> source)
     {
         return source instanceof RichIterable ? this.containsNoneIterable(source)
@@ -407,6 +461,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Testing
     default boolean containsAnyIterable(Iterable<?> source)
     {
         if (source instanceof RichIterable<?> inside)
@@ -437,6 +492,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Testing
     default boolean containsNoneIterable(Iterable<?> source)
     {
         if (source instanceof RichIterable<?> inside)
@@ -467,6 +523,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean containsAllIterable(Iterable<?> source);
 
     /**
@@ -475,6 +532,7 @@ public interface RichIterable<T>
      * @see Collection#containsAll(Collection)
      * @since 1.0
      */
+    @Testing
     boolean containsAll(Collection<?> source);
 
     /**
@@ -482,6 +540,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean containsAllArguments(Object... elements);
 
     /**
@@ -490,6 +549,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean anySatisfy(Predicate<? super T> predicate);
 
     /**
@@ -498,6 +558,7 @@ public interface RichIterable<T>
      *
      * @since 5.0
      */
+    @Testing
     <P> boolean anySatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -506,6 +567,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Testing
     boolean allSatisfy(Predicate<? super T> predicate);
 
     /**
@@ -513,6 +575,7 @@ public interface RichIterable<T>
      *
      * @since 5.0
      */
+    @Testing
     <P> boolean allSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -521,6 +584,7 @@ public interface RichIterable<T>
      *
      * @since 3.0
      */
+    @Testing
     boolean noneSatisfy(Predicate<? super T> predicate);
 
     /**
@@ -529,6 +593,7 @@ public interface RichIterable<T>
      *
      * @since 5.0
      */
+    @Testing
     <P> boolean noneSatisfyWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     //endregion [Category: Testing] 🧪
@@ -541,6 +606,7 @@ public interface RichIterable<T>
      * @return an element of an iterable.
      * @since 10.0
      */
+    @Finding
     default T getAny()
     {
         return this.getFirst();
@@ -559,6 +625,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#getFirst()} instead.
      */
     @Deprecated
+    @Finding
     T getFirst();
 
     /**
@@ -574,6 +641,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#getLast()} instead.
      */
     @Deprecated
+    @Finding
     T getLast();
 
     /**
@@ -583,6 +651,7 @@ public interface RichIterable<T>
      * @throws IllegalStateException if iterable is empty or has multiple elements.
      * @since 8.0
      */
+    @Finding
     default T getOnly()
     {
         if (this.size() == 1)
@@ -605,6 +674,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Finding
     T detect(Predicate<? super T> predicate);
 
     /**
@@ -619,6 +689,7 @@ public interface RichIterable<T>
      *
      * @since 5.0
      */
+    @Finding
     <P> T detectWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -634,6 +705,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the element selected is null
      * @since 8.0
      */
+    @Finding
     Optional<T> detectOptional(Predicate<? super T> predicate);
 
     /**
@@ -649,6 +721,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the element selected is null
      * @since 8.0
      */
+    @Finding
     <P> Optional<T> detectWithOptional(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -657,6 +730,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Finding
     default T detectIfNone(Predicate<? super T> predicate, Function0<? extends T> function)
     {
         T result = this.detect(predicate);
@@ -669,6 +743,7 @@ public interface RichIterable<T>
      *
      * @since 5.0
      */
+    @Finding
     <P> T detectWithIfNone(
             Predicate2<? super T, ? super P> predicate,
             P parameter,
@@ -680,6 +755,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     T min(Comparator<? super T> comparator);
 
     /**
@@ -688,6 +764,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     T max(Comparator<? super T> comparator);
 
     /**
@@ -697,6 +774,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the minimum element is null
      * @since 8.2
      */
+    @Finding
     default Optional<T> minOptional(Comparator<? super T> comparator)
     {
         if (this.isEmpty())
@@ -713,6 +791,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the maximum element is null
      * @since 8.2
      */
+    @Finding
     default Optional<T> maxOptional(Comparator<? super T> comparator)
     {
         if (this.isEmpty())
@@ -729,6 +808,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     T min();
 
     /**
@@ -738,6 +818,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     T max();
 
     /**
@@ -748,6 +829,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the minimum element is null
      * @since 8.2
      */
+    @Finding
     default Optional<T> minOptional()
     {
         if (this.isEmpty())
@@ -765,6 +847,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the maximum element is null
      * @since 8.2
      */
+    @Finding
     default Optional<T> maxOptional()
     {
         if (this.isEmpty())
@@ -780,6 +863,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     <V extends Comparable<? super V>> T minBy(Function<? super T, ? extends V> function);
 
     /**
@@ -788,6 +872,7 @@ public interface RichIterable<T>
      * @throws NoSuchElementException if the RichIterable is empty
      * @since 1.0
      */
+    @Finding
     <V extends Comparable<? super V>> T maxBy(Function<? super T, ? extends V> function);
 
     /**
@@ -797,6 +882,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the minimum element is null
      * @since 8.2
      */
+    @Finding
     default <V extends Comparable<? super V>> Optional<T> minByOptional(Function<? super T, ? extends V> function)
     {
         if (this.isEmpty())
@@ -813,6 +899,7 @@ public interface RichIterable<T>
      * @throws NullPointerException if the maximum element is null
      * @since 8.2
      */
+    @Finding
     default <V extends Comparable<? super V>> Optional<T> maxByOptional(Function<? super T, ? extends V> function)
     {
         if (this.isEmpty())
@@ -838,6 +925,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Filtering
     RichIterable<T> select(Predicate<? super T> predicate);
 
     /**
@@ -856,6 +944,7 @@ public interface RichIterable<T>
      * @see #select(Predicate)
      * @since 1.0
      */
+    @Filtering
     <R extends Collection<T>> R select(Predicate<? super T> predicate, R target);
 
     /**
@@ -874,6 +963,7 @@ public interface RichIterable<T>
      * @see #select(Predicate)
      * @since 5.0
      */
+    @Filtering
     <P> RichIterable<T> selectWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -895,6 +985,7 @@ public interface RichIterable<T>
      * @see #select(Predicate, Collection)
      * @since 1.0
      */
+    @Filtering
     <P, R extends Collection<T>> R selectWith(
             Predicate2<? super T, ? super P> predicate,
             P parameter,
@@ -914,6 +1005,7 @@ public interface RichIterable<T>
      * @return a RichIterable that contains elements that cause {@link Predicate#accept(Object)} method to evaluate to false
      * @since 1.0
      */
+    @Filtering
     RichIterable<T> reject(Predicate<? super T> predicate);
 
     /**
@@ -932,6 +1024,7 @@ public interface RichIterable<T>
      * @see #select(Predicate)
      * @since 5.0
      */
+    @Filtering
     <P> RichIterable<T> rejectWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     /**
@@ -948,6 +1041,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the reject criteria
      * @since 1.0
      */
+    @Filtering
     <R extends Collection<T>> R reject(Predicate<? super T> predicate, R target);
 
     /**
@@ -969,6 +1063,7 @@ public interface RichIterable<T>
      * @see #reject(Predicate, Collection)
      * @since 1.0
      */
+    @Filtering
     <P, R extends Collection<T>> R rejectWith(
             Predicate2<? super T, ? super P> predicate,
             P parameter,
@@ -984,6 +1079,7 @@ public interface RichIterable<T>
      *
      * @since 2.0
      */
+    @Filtering
     <S> RichIterable<S> selectInstancesOf(Class<S> clazz);
 
     /**
@@ -997,6 +1093,7 @@ public interface RichIterable<T>
      *
      * @since 1.0.
      */
+    @Filtering
     PartitionIterable<T> partition(Predicate<? super T> predicate);
 
     /**
@@ -1010,6 +1107,7 @@ public interface RichIterable<T>
      *
      * @since 5.0.
      */
+    @Filtering
     <P> PartitionIterable<T> partitionWith(Predicate2<? super T, ? super P> predicate, P parameter);
 
     //endregion [Category: Filtering] 🚰
@@ -1028,6 +1126,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Transforming
     <V> RichIterable<V> collect(Function<? super T, ? extends V> function);
 
     /**
@@ -1046,6 +1145,7 @@ public interface RichIterable<T>
      * @see #collect(Function)
      * @since 1.0
      */
+    @Transforming
     <V, R extends Collection<V>> R collect(Function<? super T, ? extends V> function, R target);
 
     /**
@@ -1060,6 +1160,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     BooleanIterable collectBoolean(BooleanFunction<? super T> booleanFunction);
 
     /**
@@ -1077,6 +1178,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableBooleanCollection> R collectBoolean(BooleanFunction<? super T> booleanFunction, R target)
     {
         this.forEach(each -> target.add(booleanFunction.booleanValueOf(each)));
@@ -1095,6 +1197,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     ByteIterable collectByte(ByteFunction<? super T> byteFunction);
 
     /**
@@ -1112,6 +1215,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableByteCollection> R collectByte(ByteFunction<? super T> byteFunction, R target)
     {
         this.forEach(each -> target.add(byteFunction.byteValueOf(each)));
@@ -1130,6 +1234,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     CharIterable collectChar(CharFunction<? super T> charFunction);
 
     /**
@@ -1147,6 +1252,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableCharCollection> R collectChar(CharFunction<? super T> charFunction, R target)
     {
         this.forEach(each -> target.add(charFunction.charValueOf(each)));
@@ -1165,6 +1271,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     DoubleIterable collectDouble(DoubleFunction<? super T> doubleFunction);
 
     /**
@@ -1182,6 +1289,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableDoubleCollection> R collectDouble(DoubleFunction<? super T> doubleFunction, R target)
     {
         this.forEach(each -> target.add(doubleFunction.doubleValueOf(each)));
@@ -1200,6 +1308,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     FloatIterable collectFloat(FloatFunction<? super T> floatFunction);
 
     /**
@@ -1217,6 +1326,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableFloatCollection> R collectFloat(FloatFunction<? super T> floatFunction, R target)
     {
         this.forEach(each -> target.add(floatFunction.floatValueOf(each)));
@@ -1235,6 +1345,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     IntIterable collectInt(IntFunction<? super T> intFunction);
 
     /**
@@ -1252,6 +1363,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableIntCollection> R collectInt(IntFunction<? super T> intFunction, R target)
     {
         this.forEach(each -> target.add(intFunction.intValueOf(each)));
@@ -1270,6 +1382,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     LongIterable collectLong(LongFunction<? super T> longFunction);
 
     /**
@@ -1287,6 +1400,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableLongCollection> R collectLong(LongFunction<? super T> longFunction, R target)
     {
         this.forEach(each -> target.add(longFunction.longValueOf(each)));
@@ -1305,6 +1419,7 @@ public interface RichIterable<T>
      *
      * @since 4.0
      */
+    @Transforming
     ShortIterable collectShort(ShortFunction<? super T> shortFunction);
 
     /**
@@ -1322,6 +1437,7 @@ public interface RichIterable<T>
      * @return {@code target}, which contains appended elements as a result of the collect transformation
      * @since 5.0
      */
+    @Transforming
     default <R extends MutableShortCollection> R collectShort(ShortFunction<? super T> shortFunction, R target)
     {
         this.forEach(each -> target.add(shortFunction.shortValueOf(each)));
@@ -1343,6 +1459,7 @@ public interface RichIterable<T>
      * @see #collect(Function)
      * @since 5.0
      */
+    @Transforming
     <P, V> RichIterable<V> collectWith(Function2<? super T, ? super P, ? extends V> function, P parameter);
 
     /**
@@ -1360,6 +1477,7 @@ public interface RichIterable<T>
      * @return {@code targetCollection}, which contains appended elements as a result of the collect transformation
      * @since 1.0
      */
+    @Transforming
     <P, V, R extends Collection<V>> R collectWith(
             Function2<? super T, ? super P, ? extends V> function,
             P parameter,
@@ -1382,6 +1500,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Transforming
     <V> RichIterable<V> collectIf(Predicate<? super T> predicate, Function<? super T, ? extends V> function);
 
     /**
@@ -1394,6 +1513,7 @@ public interface RichIterable<T>
      * @see #collectIf(Predicate, Function)
      * @since 1.0
      */
+    @Transforming
     <V, R extends Collection<V>> R collectIf(
             Predicate<? super T> predicate,
             Function<? super T, ? extends V> function,
@@ -1422,6 +1542,7 @@ public interface RichIterable<T>
      * @return a new flattened collection produced by applying the given {@code function}
      * @since 1.0
      */
+    @Transforming
     <V> RichIterable<V> flatCollect(Function<? super T, ? extends Iterable<V>> function);
 
     /**
@@ -1429,6 +1550,7 @@ public interface RichIterable<T>
      *
      * @since 9.2
      */
+    @Transforming
     default <P, V> RichIterable<V> flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter)
     {
         return this.flatCollect(each -> function.apply(each, parameter));
@@ -1442,6 +1564,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     <V, R extends Collection<V>> R flatCollect(Function<? super T, ? extends Iterable<V>> function, R target);
 
     /**
@@ -1449,6 +1572,7 @@ public interface RichIterable<T>
      *
      * @since 9.2
      */
+    @Transforming
     default <P, V, R extends Collection<V>> R flatCollectWith(Function2<? super T, ? super P, ? extends Iterable<V>> function, P parameter, R target)
     {
         return this.flatCollect(each -> function.apply(each, parameter), target);
@@ -1462,6 +1586,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableByteCollection> R flatCollectByte(Function<? super T, ? extends ByteIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1476,6 +1601,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableCharCollection> R flatCollectChar(Function<? super T, ? extends CharIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1490,6 +1616,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableIntCollection> R flatCollectInt(Function<? super T, ? extends IntIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1504,6 +1631,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableShortCollection> R flatCollectShort(Function<? super T, ? extends ShortIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1518,6 +1646,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableDoubleCollection> R flatCollectDouble(Function<? super T, ? extends DoubleIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1532,6 +1661,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableFloatCollection> R flatCollectFloat(Function<? super T, ? extends FloatIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1546,6 +1676,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableLongCollection> R flatCollectLong(Function<? super T, ? extends LongIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1560,6 +1691,7 @@ public interface RichIterable<T>
      * @return {@code target}, which will contain a flattened collection of results produced by applying the given {@code function}
      * @see #flatCollect(Function)
      */
+    @Transforming
     default <R extends MutableBooleanCollection> R flatCollectBoolean(Function<? super T, ? extends BooleanIterable> function, R target)
     {
         this.forEach(each -> target.addAll(function.valueOf(each)));
@@ -1580,6 +1712,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable)} instead.
      */
     @Deprecated
+    @Transforming
     <S> RichIterable<Pair<T, S>> zip(Iterable<S> that);
 
     /**
@@ -1589,6 +1722,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#zip(Iterable, Collection)} instead;
      */
     @Deprecated
+    @Transforming
     <S, R extends Collection<Pair<T, S>>> R zip(Iterable<S> that, R target);
 
     /**
@@ -1601,6 +1735,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex()} instead.
      */
     @Deprecated
+    @Transforming
     RichIterable<Pair<T, Integer>> zipWithIndex();
 
     /**
@@ -1610,6 +1745,7 @@ public interface RichIterable<T>
      * @deprecated in 6.0. Use {@link OrderedIterable#zipWithIndex(Collection)} instead.
      */
     @Deprecated
+    @Transforming
     <R extends Collection<Pair<T, Integer>>> R zipWithIndex(R target);
 
     //endregion [Category: Transforming] 🦋
@@ -1629,6 +1765,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Grouping
     <V> Multimap<V, T> groupBy(Function<? super T, ? extends V> function);
 
     /**
@@ -1643,6 +1780,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Grouping
     <V, R extends MutableMultimap<V, T>> R groupBy(Function<? super T, ? extends V> function, R target);
 
     /**
@@ -1651,6 +1789,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Grouping
     <V> Multimap<V, T> groupByEach(Function<? super T, ? extends Iterable<V>> function);
 
     /**
@@ -1659,6 +1798,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Grouping
     <V, R extends MutableMultimap<V, T>> R groupByEach(
             Function<? super T, ? extends Iterable<V>> function,
             R target);
@@ -1672,6 +1812,7 @@ public interface RichIterable<T>
      * @see #groupBy(Function)
      * @since 5.0
      */
+    @Grouping
     <V> MapIterable<V, T> groupByUniqueKey(Function<? super T, ? extends V> function);
 
     /**
@@ -1682,6 +1823,7 @@ public interface RichIterable<T>
      * @see #groupByUniqueKey(Function)
      * @since 6.0
      */
+    @Grouping
     <V, R extends MutableMapIterable<V, T>> R groupByUniqueKey(
             Function<? super T, ? extends V> function,
             R target);
@@ -1694,6 +1836,7 @@ public interface RichIterable<T>
      * truncated if the elements don't divide evenly.
      * @since 1.0
      */
+    @Grouping
     RichIterable<RichIterable<T>> chunk(int size);
 
     /**
@@ -1710,6 +1853,7 @@ public interface RichIterable<T>
      *
      * @since 10.1.0
      */
+    @Grouping
     default <K, V, R extends MutableMultimap<K, V>> R groupByAndCollect(
             Function<? super T, ? extends K> groupByFunction,
             Function<? super T, ? extends V> collectFunction,
@@ -1730,6 +1874,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Aggregating
     <IV> IV injectInto(IV injectedValue, Function2<? super IV, ? super T, ? extends IV> function);
 
     /**
@@ -1741,6 +1886,7 @@ public interface RichIterable<T>
      * @deprecated since 11.1 - use injectIntoInt instead
      */
     @Deprecated
+    @Aggregating
     int injectInto(int injectedValue, IntObjectToIntFunction<? super T> function);
 
     /**
@@ -1750,6 +1896,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Aggregating
     default int injectIntoInt(int injectedValue, IntObjectToIntFunction<? super T> function)
     {
         return this.injectInto(injectedValue, function);
@@ -1764,6 +1911,7 @@ public interface RichIterable<T>
      * @deprecated since 11.1 - use injectIntoLong instead
      */
     @Deprecated
+    @Aggregating
     long injectInto(long injectedValue, LongObjectToLongFunction<? super T> function);
 
     /**
@@ -1773,6 +1921,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Aggregating
     default long injectIntoLong(long injectedValue, LongObjectToLongFunction<? super T> function)
     {
         return this.injectInto(injectedValue, function);
@@ -1787,6 +1936,7 @@ public interface RichIterable<T>
      * @deprecated since 11.1 - use injectIntoFloat instead
      */
     @Deprecated
+    @Aggregating
     float injectInto(float injectedValue, FloatObjectToFloatFunction<? super T> function);
 
     /**
@@ -1796,6 +1946,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Aggregating
     default float injectIntoFloat(float injectedValue, FloatObjectToFloatFunction<? super T> function)
     {
         return this.injectInto(injectedValue, function);
@@ -1810,6 +1961,7 @@ public interface RichIterable<T>
      * @deprecated since 11.1 - use injectIntoDouble instead
      */
     @Deprecated
+    @Aggregating
     double injectInto(double injectedValue, DoubleObjectToDoubleFunction<? super T> function);
 
     /**
@@ -1819,6 +1971,7 @@ public interface RichIterable<T>
      *
      * @since 11.1
      */
+    @Aggregating
     default double injectIntoDouble(double injectedValue, DoubleObjectToDoubleFunction<? super T> function)
     {
         return this.injectInto(injectedValue, function);
@@ -1830,6 +1983,7 @@ public interface RichIterable<T>
      *
      * @since 2.0
      */
+    @Aggregating
     long sumOfInt(IntFunction<? super T> function);
 
     /**
@@ -1838,6 +1992,7 @@ public interface RichIterable<T>
      *
      * @since 2.0
      */
+    @Aggregating
     double sumOfFloat(FloatFunction<? super T> function);
 
     /**
@@ -1846,6 +2001,7 @@ public interface RichIterable<T>
      *
      * @since 2.0
      */
+    @Aggregating
     long sumOfLong(LongFunction<? super T> function);
 
     /**
@@ -1854,6 +2010,7 @@ public interface RichIterable<T>
      *
      * @since 2.0
      */
+    @Aggregating
     double sumOfDouble(DoubleFunction<? super T> function);
 
     /**
@@ -1867,6 +2024,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default IntSummaryStatistics summarizeInt(IntFunction<? super T> function)
     {
         IntSummaryStatistics stats = new IntSummaryStatistics();
@@ -1885,6 +2043,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default DoubleSummaryStatistics summarizeFloat(FloatFunction<? super T> function)
     {
         DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
@@ -1903,6 +2062,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default LongSummaryStatistics summarizeLong(LongFunction<? super T> function)
     {
         LongSummaryStatistics stats = new LongSummaryStatistics();
@@ -1921,6 +2081,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default DoubleSummaryStatistics summarizeDouble(DoubleFunction<? super T> function)
     {
         DoubleSummaryStatistics stats = new DoubleSummaryStatistics();
@@ -1938,6 +2099,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default <R, A> R reduceInPlace(Collector<? super T, A, R> collector)
     {
         A mutableResult = collector.supplier().get();
@@ -1952,6 +2114,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default <R> R reduceInPlace(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator)
     {
         R result = supplier.get();
@@ -1964,6 +2127,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Aggregating
     default Optional<T> reduce(BinaryOperator<T> accumulator)
     {
         boolean[] seenOne = new boolean[1];
@@ -1988,6 +2152,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Aggregating
     <V> ObjectLongMap<V> sumByInt(Function<? super T, ? extends V> groupBy, IntFunction<? super T> function);
 
     /**
@@ -1995,6 +2160,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Aggregating
     <V> ObjectDoubleMap<V> sumByFloat(Function<? super T, ? extends V> groupBy, FloatFunction<? super T> function);
 
     /**
@@ -2002,6 +2168,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Aggregating
     <V> ObjectLongMap<V> sumByLong(Function<? super T, ? extends V> groupBy, LongFunction<? super T> function);
 
     /**
@@ -2009,6 +2176,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Aggregating
     <V> ObjectDoubleMap<V> sumByDouble(Function<? super T, ? extends V> groupBy, DoubleFunction<? super T> function);
 
     /**
@@ -2018,6 +2186,7 @@ public interface RichIterable<T>
      *
      * @since 3.0
      */
+    @Aggregating
     default <K, V> MapIterable<K, V> aggregateInPlaceBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -2040,6 +2209,7 @@ public interface RichIterable<T>
      *
      * @since 3.0
      */
+    @Aggregating
     default <K, V> MapIterable<K, V> aggregateBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -2059,6 +2229,7 @@ public interface RichIterable<T>
      *
      * @since 10.3
      */
+    @Aggregating
     default <K, V, R extends MutableMapIterable<K, V>> R aggregateBy(
             Function<? super T, ? extends K> groupBy,
             Function0<? extends V> zeroValueFactory,
@@ -2080,6 +2251,7 @@ public interface RichIterable<T>
      * @since 12.0
      *
      */
+    @Aggregating
     default <K> MapIterable<K, T> reduceBy(
             Function<? super T, ? extends K> groupBy,
             Function2<? super T, ? super T, ? extends T> reduceFunction)
@@ -2096,6 +2268,7 @@ public interface RichIterable<T>
      *
      * @since 12.0
      */
+    @Aggregating
     default <K, R extends MutableMapIterable<K, T>> R reduceBy(
             Function<? super T, ? extends K> groupBy,
             Function2<? super T, ? super T, ? extends T> reduceFunction,
@@ -2118,6 +2291,7 @@ public interface RichIterable<T>
      *
      * @since 8.0
      */
+    @Converting
     <R extends Collection<T>> R into(R target);
 
     /**
@@ -2125,6 +2299,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     MutableList<T> toList();
 
     /**
@@ -2132,6 +2307,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default MutableList<T> toSortedList()
     {
         return this.toList().sortThis();
@@ -2142,6 +2318,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default MutableList<T> toSortedList(Comparator<? super T> comparator)
     {
         return this.toList().sortThis(comparator);
@@ -2153,6 +2330,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default <V extends Comparable<? super V>> MutableList<T> toSortedListBy(Function<? super T, ? extends V> function)
     {
         return this.toSortedList(SerializableComparators.byFunction(function));
@@ -2163,6 +2341,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     MutableSet<T> toSet();
 
     /**
@@ -2171,6 +2350,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     MutableSortedSet<T> toSortedSet();
 
     /**
@@ -2178,6 +2358,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     MutableSortedSet<T> toSortedSet(Comparator<? super T> comparator);
 
     /**
@@ -2186,6 +2367,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default <V extends Comparable<? super V>> MutableSortedSet<T> toSortedSetBy(Function<? super T, ? extends V> function)
     {
         return this.toSortedSet(SerializableComparators.byFunction(function));
@@ -2196,6 +2378,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     MutableBag<T> toBag();
 
     /**
@@ -2204,6 +2387,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Converting
     MutableSortedBag<T> toSortedBag();
 
     /**
@@ -2211,6 +2395,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Converting
     MutableSortedBag<T> toSortedBag(Comparator<? super T> comparator);
 
     /**
@@ -2219,6 +2404,7 @@ public interface RichIterable<T>
      *
      * @since 6.0
      */
+    @Converting
     default <V extends Comparable<? super V>> MutableSortedBag<T> toSortedBagBy(Function<? super T, ? extends V> function)
     {
         return this.toSortedBag(SerializableComparators.byFunction(function));
@@ -2229,6 +2415,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     <NK, NV> MutableMap<NK, NV> toMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction);
@@ -2239,6 +2426,7 @@ public interface RichIterable<T>
      *
      * @since 10.0
      */
+    @Converting
     default <NK, NV, R extends Map<NK, NV>> R toMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction,
@@ -2254,6 +2442,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     <NK, NV> MutableSortedMap<NK, NV> toSortedMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction);
@@ -2264,6 +2453,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     <NK, NV> MutableSortedMap<NK, NV> toSortedMap(
             Comparator<? super NK> comparator,
             Function<? super T, ? extends NK> keyFunction,
@@ -2273,6 +2463,7 @@ public interface RichIterable<T>
      * Converts the collection to a MutableSortedMap implementation using the specified key and value functions
      * and sorts it based on the natural order of the attribute returned by {@code sortBy} function.
      */
+    @Converting
     default <KK extends Comparable<? super KK>, NK, NV> MutableSortedMap<NK, NV> toSortedMapBy(
             Function<? super NK, KK> sortBy,
             Function<? super T, ? extends NK> keyFunction,
@@ -2286,6 +2477,7 @@ public interface RichIterable<T>
      *
      * @since 10.0
      */
+    @Converting
     <NK, NV> MutableBiMap<NK, NV> toBiMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction);
@@ -2295,6 +2487,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableList<T> toImmutableList()
     {
         return Lists.immutable.withAll(this);
@@ -2305,6 +2498,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableSet<T> toImmutableSet()
     {
         return Sets.immutable.withAll(this);
@@ -2315,6 +2509,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableBag<T> toImmutableBag()
     {
         return Bags.immutable.withAll(this);
@@ -2325,6 +2520,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableList<T> toImmutableSortedList()
     {
         return Lists.immutable.withAllSorted(this);
@@ -2335,6 +2531,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableList<T> toImmutableSortedList(Comparator<? super T> comparator)
     {
         return Lists.immutable.withAllSorted(comparator, this);
@@ -2346,6 +2543,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default <V extends Comparable<? super V>> ImmutableList<T> toImmutableSortedListBy(Function<? super T, ? extends V> function)
     {
         return this.toImmutableSortedList(Comparator.comparing(function));
@@ -2356,6 +2554,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableSortedSet<T> toImmutableSortedSet()
     {
         return SortedSets.immutable.withAll(this);
@@ -2366,6 +2565,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableSortedSet<T> toImmutableSortedSet(Comparator<? super T> comparator)
     {
         return SortedSets.immutable.withAll(comparator, this);
@@ -2377,6 +2577,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default <V extends Comparable<? super V>> ImmutableSortedSet<T> toImmutableSortedSetBy(Function<? super T, ? extends V> function)
     {
         return this.toImmutableSortedSet(Comparator.comparing(function));
@@ -2387,6 +2588,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableSortedBag<T> toImmutableSortedBag()
     {
         return SortedBags.immutable.withAll(this);
@@ -2397,6 +2599,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default ImmutableSortedBag<T> toImmutableSortedBag(Comparator<? super T> comparator)
     {
         return SortedBags.immutable.withAll(comparator, this);
@@ -2408,6 +2611,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default <V extends Comparable<? super V>> ImmutableSortedBag<T> toImmutableSortedBagBy(Function<? super T, ? extends V> function)
     {
         return this.toImmutableSortedBag(Comparator.comparing(function));
@@ -2418,6 +2622,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default <NK, NV> ImmutableMap<NK, NV> toImmutableMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction)
@@ -2430,6 +2635,7 @@ public interface RichIterable<T>
      *
      * @since 11.0
      */
+    @Converting
     default <NK, NV> ImmutableBiMap<NK, NV> toImmutableBiMap(
             Function<? super T, ? extends NK> keyFunction,
             Function<? super T, ? extends NV> valueFunction)
@@ -2443,6 +2649,7 @@ public interface RichIterable<T>
      * @see Collection#toArray()
      * @since 1.0
      */
+    @Converting
     default Object[] toArray()
     {
         Object[] result = new Object[this.size()];
@@ -2457,6 +2664,7 @@ public interface RichIterable<T>
      * @see Collection#toArray(Object[])
      * @since 1.0
      */
+    @Converting
     default <E> E[] toArray(E[] array)
     {
         int size = this.size();
@@ -2486,6 +2694,7 @@ public interface RichIterable<T>
      * @see java.util.AbstractCollection#toString()
      * @since 1.0
      */
+    @Converting
     @Override
     String toString();
 
@@ -2496,6 +2705,7 @@ public interface RichIterable<T>
      * @return a string representation of this collection.
      * @since 1.0
      */
+    @Converting
     default String makeString()
     {
         return this.makeString(", ");
@@ -2508,6 +2718,7 @@ public interface RichIterable<T>
      * @return a string representation of this collection.
      * @since 1.0
      */
+    @Converting
     default String makeString(String separator)
     {
         return this.makeString("", separator, "");
@@ -2520,6 +2731,7 @@ public interface RichIterable<T>
      * @return a string representation of this collection.
      * @since 1.0
      */
+    @Converting
     default String makeString(String start, String separator, String end)
     {
         Appendable stringBuilder = new StringBuilder();
@@ -2533,6 +2745,7 @@ public interface RichIterable<T>
      *
      * @return a string representation of the mapped collection
      */
+    @Converting
     default String makeString(Function<? super T, Object> function, String start, String separator, String end)
     {
         return this.asLazy().collect(function).makeString(start, separator, end);
@@ -2544,6 +2757,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default void appendString(Appendable appendable)
     {
         this.appendString(appendable, ", ");
@@ -2555,6 +2769,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     default void appendString(Appendable appendable, String separator)
     {
         this.appendString(appendable, "", separator, "");
@@ -2566,6 +2781,7 @@ public interface RichIterable<T>
      *
      * @since 1.0
      */
+    @Converting
     void appendString(Appendable appendable, String start, String separator, String end);
 
     //endregion [Category: Converting] 🔌

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Aggregating.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Aggregating.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Aggregating</b> category.
+ * Aggregating methods combine or reduce elements of a collection into a single result value,
+ * such as sums, statistics, folds, or custom aggregations.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Aggregating", icon = "📊")
+public @interface Aggregating
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Category.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Category.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta-annotation that identifies the category name for a category annotation.
+ * All category annotations in this package are annotated with {@code @Category}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Category
+{
+    /**
+     * The name of the category.
+     */
+    String value();
+
+    /**
+     * The icon that represents the category.
+     */
+    String icon() default "";
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Converting.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Converting.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Converting</b> category.
+ * Converting methods transform a collection into another type, such as a List, Set, Bag, Map,
+ * array, or String representation.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Converting", icon = "🔌")
+public @interface Converting
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Counting.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Counting.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Counting</b> category.
+ * Counting methods return the number of elements in a collection or the number of elements satisfying a condition.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Counting", icon = "🔢")
+public @interface Counting
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Filtering.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Filtering.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Filtering</b> category.
+ * Filtering methods select or reject elements from a collection based on a predicate,
+ * or partition elements into two groups.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Filtering", icon = "🚰")
+public @interface Filtering
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Finding.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Finding.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Finding</b> category.
+ * Finding methods locate specific elements within a collection, such as the first, last, minimum, or maximum element.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Finding", icon = "🔎")
+public @interface Finding
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Grouping.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Grouping.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Grouping</b> category.
+ * Grouping methods organize elements of a collection into groups based on a key function,
+ * returning a multimap, map, or partitioned collection.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Grouping", icon = "🏘️")
+public @interface Grouping
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Iterating.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Iterating.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Iterating</b> category.
+ * Iterating methods traverse elements of a collection, executing a procedure for each element.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Iterating", icon = "🔄")
+public @interface Iterating
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Mutating.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Mutating.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Mutating</b> category.
+ * Mutating methods modify the state or contents of a collection.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Mutating", icon = "🧬")
+public @interface Mutating
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Testing.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Testing.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Testing</b> category.
+ * Testing methods evaluate conditions against elements of a collection and return a boolean result.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Testing", icon = "🧪")
+public @interface Testing
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Transforming.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/Transforming.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.api.annotation.category;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as belonging to the <b>Transforming</b> category.
+ * Transforming methods apply a function to each element of a collection, producing a new collection
+ * of transformed values (also known as map or flatMap operations).
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Category(value = "Transforming", icon = "🦋")
+public @interface Transforming
+{
+}

--- a/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/package-info.java
+++ b/eclipse-collections-api/src/main/java/org/eclipse/collections/api/annotation/category/package-info.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+/**
+ * This package contains category annotations for classifying methods in the Eclipse Collections API.
+ * <p>
+ * These annotations mirror the foldable regions in {@link org.eclipse.collections.api.RichIterable}
+ * and serve as a machine-readable classification system for its methods. Each category annotation is
+ * itself annotated with {@link org.eclipse.collections.api.annotation.category.Category}, which carries
+ * the category name and icon.
+ * </p>
+ * <p>
+ * The following categories are defined, with links to all annotated methods (class-use pages):
+ * </p>
+ * <ul>
+ *     <li><a href="class-use/Aggregating.html">Aggregating 📊</a>
+ *         - Methods that reduce or fold elements into a single result</li>
+ *     <li><a href="class-use/Converting.html">Converting 🔌</a>
+ *         - Methods that convert a collection to another type or representation</li>
+ *     <li><a href="class-use/Counting.html">Counting 🔢</a>
+ *         - Methods that count elements or occurrences</li>
+ *     <li><a href="class-use/Filtering.html">Filtering 🚰</a>
+ *         - Methods that select, reject, or partition elements based on a predicate</li>
+ *     <li><a href="class-use/Finding.html">Finding 🔎</a>
+ *         - Methods that locate specific elements such as first, last, min, or max</li>
+ *     <li><a href="class-use/Grouping.html">Grouping 🏘️</a>
+ *         - Methods that organize elements into groups by a key function</li>
+ *     <li><a href="class-use/Iterating.html">Iterating 🔄</a>
+ *         - Methods that traverse elements of a collection</li>
+ *     <li><a href="class-use/Mutating.html">Mutating 🧬</a>
+ *         - Methods that modify the state or contents of a collection</li>
+ *     <li><a href="class-use/Testing.html">Testing 🧪</a>
+ *         - Methods that evaluate boolean conditions against elements</li>
+ *     <li><a href="class-use/Transforming.html">Transforming 🦋</a>
+ *         - Methods that apply a function to each element, producing a new collection</li>
+ * </ul>
+ */
+package org.eclipse.collections.api.annotation.category;


### PR DESCRIPTION
PoC using annotations to categorise `RichIterable` methods (under @donraab's guidance).

## Advantages complementary to foldable regions:

1. Improved Javadocs, displaying the category for each method: <img width="1105" height="277" alt="image" src="https://github.com/user-attachments/assets/1ac1dd7c-832c-4bdf-8191-87bc862c167e" />
2. Similar to foldable regions, it enables users to navigate categories using the "Find Usages" feature of IDEs such as IntelliJ IDEA, but now at a global level.
3. Global "Category Usage" index in `package-info`, linking to automatically generated usage indexes per category across packages, classes, and interfaces. See it in action at:
   https://aaccioly-open-source.github.io/eclipse-collections/javadocs/org/eclipse/collections/api/annotation/category/package-summary.html
4. Indexes are now sorted and can be generated automatically by introspecting class annotations.

## Potential downsides:

* Additional maintenance overhead when adding new methods to the API:
  * Determine the appropriate category.
  * Update the index.
  * Add the method in the correct position within the corresponding folding region.

## Disclaimer:

This is an initial PR to evaluate the approach and get some feedback from maintainers.

@donraab and I have already classified several other interfaces behind the scenes while working on an AI skill  and a series of Open Rewrite rules to automatically classify methods. If maintainers decide to support this approach, the plan is to submit a series of small PRs, each categorising a limited number of interfaces/classes. This should make reviews more manageable and allow time for discussion around the proposed classifications.

In parallel, we intend to continue improving the AI classifier skill, which is planned to be released as a standalone open source project. This approach respects the Eclipse Collections AI policy by keeping AI-related assets outside the repository.

For this PR, I used Claude Opus to classify methods and validate them against the previous manual classifications. However, I did not use AI to generate any of the code itself.

This may change in future PRs, where the custom skill and Claude Opus may be used more explicitly to assist with modifications to API classes and interfaces, and as such, I'll add git commit trailers as required by Eclipse Collection AI's policy.
